### PR TITLE
docs(db): document phase-state migration rollout lock strategy

### DIFF
--- a/M19_RELEASE_EVIDENCE.md
+++ b/M19_RELEASE_EVIDENCE.md
@@ -76,6 +76,11 @@ Observed Playwright results:
   - route-handler integration proof with in-memory database seam
   - browser e2e user flows passing
 
+3. Phase-state migration rollout lock sensitivity is operational (documented strategy)
+- `app/supabase/migrations/20260221_000002_add_meeting_phase_state.sql` uses standard index DDL on `public.shares`
+- Use low-traffic / maintenance-window rollout by default, or split/manual concurrent index DDL if production traffic requires it
+- See `app/supabase/migrations/README.md` (post-ship hardening issue `#16`)
+
 ## Release Readiness Assessment
 
 - Core functionality (M11-M19 active paths): Verified

--- a/app/supabase/migrations/README.md
+++ b/app/supabase/migrations/README.md
@@ -1,0 +1,49 @@
+# Supabase Migration Rollout Notes
+
+## M18 phase-state migration (`20260221_000002_add_meeting_phase_state.sql`)
+
+### Why this note exists
+
+This migration adds:
+
+- `meetings.phase_state` (`jsonb`)
+- `shares.voice_candidate_metadata` (`jsonb`)
+- indexes including `idx_shares_voice_candidate` on `shares`
+
+The index statements are standard `DROP INDEX` / `CREATE INDEX` operations, which can take stronger locks on `public.shares` than desired during a live production rollout.
+
+### Decision (post-ship hardening issue `#16`)
+
+Default rollout strategy for this migration is:
+
+1. Apply the migration during a low-traffic window / maintenance window.
+2. Verify completion before restoring normal traffic.
+
+We are **not** rewriting the committed migration to use `CONCURRENTLY` in-place because:
+
+- PostgreSQL forbids `CREATE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` inside transaction blocks.
+- Migration runners commonly wrap migration files in transactions.
+- Changing an already-shipped migration file is riskier than documenting a safe rollout procedure.
+
+### If live traffic makes locking risk unacceptable
+
+Use a split/manual strategy instead of editing the committed migration:
+
+1. Run the non-index parts of the migration (or a split copy) in the normal migration path.
+2. Run index changes as manual SQL outside a transaction using a DB console/session:
+   - `DROP INDEX CONCURRENTLY IF EXISTS idx_shares_voice_candidate;`
+   - `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_shares_voice_candidate ON public.shares (((voice_candidate_metadata->>'voiceConsistency')::int));`
+3. Record the exact commands and timing in release evidence / deployment notes.
+
+### Rollout checks (recommended)
+
+- Before applying: confirm expected traffic window and rollback owner
+- During apply: monitor active locks / query activity if available
+- After apply:
+  - verify `meetings.phase_state` and `shares.voice_candidate_metadata` columns exist
+  - verify `idx_meetings_phase` and `idx_shares_voice_candidate` indexes exist
+  - run a smoke flow (`share` -> `user-share` -> `close`) and confirm no migration-related errors
+
+### Reminder
+
+This file documents **operational rollout guidance**. It does not replace environment-specific DB migration commands (`supabase db push`, SQL editor, CI migration step, etc.).


### PR DESCRIPTION
## Summary
- document rollout guidance for `20260221_000002_add_meeting_phase_state.sql`
- choose maintenance-window default strategy for standard index DDL on `public.shares`
- document optional split/manual `CONCURRENTLY` path for live traffic
- reference this operational caveat in `M19_RELEASE_EVIDENCE.md`

## Why
Issue #16 identified production rollout risk from non-concurrent index operations in the phase-state migration. Rewriting an already-shipped migration file is riskier than documenting a safe rollout process and explicit operator choices.

## Notes
- No runtime code changes
- No schema SQL changed in the committed migration file
- This is deployment/process guidance only

Closes #16

## Summary by Sourcery

Document operational rollout strategy and locking considerations for the M18 phase-state database migration without changing the existing migration SQL.

Documentation:
- Add migration rollout guidance for the M18 phase-state change, including default maintenance-window deployment and optional concurrent index path for live traffic.
- Reference the migration’s lock sensitivity and rollout strategy in the M19 release evidence documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal migration documentation to reflect phase-state migration rollout procedures and known operational considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->