### PR TITLE
ci: add starter PR review-comment triage pipeline

### DIFF
--- a/.github/workflows/ci-triage-review-comments.yml
+++ b/.github/workflows/ci-triage-review-comments.yml
@@ -4,7 +4,6 @@ on:
   pull_request_review:
     types:
       - submitted
-      - edited
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,6 +19,9 @@ jobs:
   triage-review-feedback:
     name: Triage Bot Review Feedback (Informational)
     runs-on: ubuntu-latest
+    concurrency:
+      group: ci-triage-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+      cancel-in-progress: true
     # Starter triage pipeline only: informational summary + artifact.
     # This is not the final Codex-decider system and should not block PRs.
     steps:
@@ -49,4 +51,3 @@ jobs:
           name: ci-triage-summary-pr-${{ inputs.pr_number || github.event.pull_request.number || 'unknown' }}
           path: artifacts/ci-triage-summary.json
           if-no-files-found: warn
-

--- a/scripts/triage-pr-comments.mjs
+++ b/scripts/triage-pr-comments.mjs
@@ -91,12 +91,12 @@ function repoParts(repo) {
 function summarizeText(text, max = 180) {
   const normalized = String(text || "").replace(/\s+/g, " ").trim();
   if (!normalized) return "(no text)";
-  return normalized.length > max ? `${normalized.slice(0, max - 1)}...` : normalized;
+  if (max <= 3) return normalized.slice(0, Math.max(0, max));
+  return normalized.length > max ? `${normalized.slice(0, max - 3)}...` : normalized;
 }
 
 function scoreBucket(text, kind = "comment") {
   const body = String(text || "");
-  const lower = body.toLowerCase();
   const reasons = [];
   let fixNowScore = 0;
   let makeIssueScore = 0;
@@ -121,12 +121,9 @@ function scoreBucket(text, kind = "comment") {
     }
   }
 
-  if (kind === "review" && !lower.trim()) {
+  if (kind === "review" && !body.trim()) {
     ignoreScore += 1.5;
     reasons.push("empty review body");
-  }
-  if (/\bsecurity\b/i.test(body) || /\bdata loss\b/i.test(body)) {
-    fixNowScore += 2;
   }
   if (/\bquestion\b/i.test(body) || /\bclarify\b/i.test(body)) {
     makeIssueScore += 0.75;
@@ -233,7 +230,25 @@ async function fetchPaginatedJson({ url, headers }) {
     pageUrl.searchParams.set("per_page", "100");
     pageUrl.searchParams.set("page", String(page));
 
-    const res = await fetch(pageUrl, { headers });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15000);
+    let res;
+    try {
+      res = await fetch(pageUrl, { headers, signal: controller.signal });
+    } catch (error) {
+      clearTimeout(timeoutId);
+      const message =
+        error instanceof Error ? `${error.name}: ${error.message}` : summarizeText(String(error), 300);
+      return {
+        ok: false,
+        status: 408,
+        statusText: "Request failed",
+        url: pageUrl.toString(),
+        bodySnippet: summarizeText(message, 300),
+        items,
+      };
+    }
+    clearTimeout(timeoutId);
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       return {
@@ -504,4 +519,3 @@ main().catch(async (error) => {
   printSummary(fallbackSummary);
   process.exitCode = 0;
 });
-


### PR DESCRIPTION
## Summary\n- add a starter GitHub Actions workflow to triage PR review comments (informational only)\n- add a dependency-free Node script that reads GitHub PR reviews/comments and buckets likely bot feedback\n- upload triage JSON as an artifact for maintainers\n\n## What this is (and is not)\n- This is a **starter** pipeline to validate triggers/permissions/data shape\n- It is **non-blocking** and does not create issues or mutate PRs\n- It is **not** the final Codex-decider system\n\n## Current bot filters\n- Gemini\n- CodeRabbit\n- Sourcery\n\n## Buckets\n- fix-now\n- make-issue\n- ignore\n\n## Validation\n- \n- local dry-run without token (graceful skip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow to automatically triage pull request review comments and produce a summary artifact.
  * Added a starter triage tool that classifies review feedback into actionable buckets (fix-now, make-issue, ignore) and prints a concise summary to help prioritize reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->