### PR TITLE
fix(core): harden narrative context fallback handling

### DIFF
--- a/app/src/lib/core/narrative-context.spec.ts
+++ b/app/src/lib/core/narrative-context.spec.ts
@@ -64,6 +64,7 @@ describe('narrative-context quality parsing', () => {
 describe('getMeetingNarrativeContext', () => {
 	beforeEach(() => {
 		clearMeetingNarrativeContextCache();
+		vi.useRealTimers();
 	});
 
 	it('caches generated narrative context for a meeting', async () => {
@@ -124,5 +125,77 @@ describe('getMeetingNarrativeContext', () => {
 		expect(context.contextLine.toLowerCase()).toContain('undercurrent');
 		expect(context.roomFrame).toContain('folding chairs');
 		expect(context.emotionalUndercurrent).toContain('without pretending to have easy answers');
+	});
+
+	it('falls back gracefully when generateShare throws', async () => {
+		const generateShare = vi.fn(async () => {
+			throw new Error('socket hang up');
+		});
+		const grokAi = createGrokMock(generateShare);
+
+		const context = await getMeetingNarrativeContext({
+			meetingId: 'meeting-throw',
+			topic: 'honesty',
+			userName: 'Lane',
+			userMood: 'raw',
+			recentShares: [],
+			grokAi
+		});
+
+		expect(generateShare).toHaveBeenCalledTimes(1);
+		expect(context.source).toBe('fallback');
+		expect(context.roomFrame).toContain('folding chairs');
+	});
+
+	it('retries fallback context after the fallback cache ttl expires', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-03-18T12:00:00Z'));
+
+		const generateShare = vi
+			.fn<GrokAiPort['generateShare']>()
+			.mockResolvedValueOnce(err(SeamErrorCodes.UPSTREAM_UNAVAILABLE, 'network unavailable'))
+			.mockResolvedValueOnce(
+				ok({
+					shareText: JSON.stringify({
+						roomFrame: 'The coffee is burnt and the room finally settles.',
+						emotionalUndercurrent: 'People sound less armored now that someone went first.'
+					})
+				})
+			);
+		const grokAi = createGrokMock(generateShare);
+
+		const first = await getMeetingNarrativeContext({
+			meetingId: 'meeting-cache-retry',
+			topic: 'honesty',
+			userName: 'Lane',
+			userMood: 'raw',
+			recentShares: [],
+			grokAi
+		});
+		const second = await getMeetingNarrativeContext({
+			meetingId: 'meeting-cache-retry',
+			topic: 'honesty',
+			userName: 'Lane',
+			userMood: 'raw',
+			recentShares: [],
+			grokAi
+		});
+
+		vi.advanceTimersByTime(30_001);
+
+		const third = await getMeetingNarrativeContext({
+			meetingId: 'meeting-cache-retry',
+			topic: 'honesty',
+			userName: 'Lane',
+			userMood: 'raw',
+			recentShares: [],
+			grokAi
+		});
+
+		expect(generateShare).toHaveBeenCalledTimes(2);
+		expect(first.source).toBe('fallback');
+		expect(second.source).toBe('fallback');
+		expect(third.source).toBe('generated');
+		expect(third.roomFrame).toContain('The coffee is burnt');
 	});
 });

--- a/app/src/lib/core/narrative-context.ts
+++ b/app/src/lib/core/narrative-context.ts
@@ -3,8 +3,14 @@ import { EDITORIAL_REALITY_CHECKS, STYLE_CONSTITUTION } from './style-constituti
 
 const MAX_LINE_LENGTH = 220;
 const QUALITY_MIN_SCORE = 6;
+const FALLBACK_CACHE_TTL_MS = 30_000;
 
-const meetingNarrativeContextCache = new Map<string, MeetingNarrativeContext>();
+interface CachedMeetingNarrativeContext {
+	value: MeetingNarrativeContext;
+	expiresAt: number | null;
+}
+
+const meetingNarrativeContextCache = new Map<string, CachedMeetingNarrativeContext>();
 const meetingNarrativeContextInFlight = new Map<string, Promise<MeetingNarrativeContext>>();
 
 export interface MeetingNarrativeContextInput {
@@ -173,18 +179,28 @@ export async function getMeetingNarrativeContext(
 	input: MeetingNarrativeContextInput
 ): Promise<MeetingNarrativeContext> {
 	const cached = meetingNarrativeContextCache.get(input.meetingId);
-	if (cached) return cached;
+	if (cached) {
+		if (cached.expiresAt === null || cached.expiresAt > Date.now()) {
+			return cached.value;
+		}
+		meetingNarrativeContextCache.delete(input.meetingId);
+	}
 
 	const inFlight = meetingNarrativeContextInFlight.get(input.meetingId);
 	if (inFlight) return inFlight;
 
 	const pending = (async () => {
-		const generated = await input.grokAi.generateShare({
-			meetingId: input.meetingId,
-			characterId: 'meeting-narrative-context',
-			prompt: buildNarrativeContextPrompt(input),
-			contextMessages: []
-		});
+		let generated: Awaited<ReturnType<GrokAiPort['generateShare']>>;
+		try {
+			generated = await input.grokAi.generateShare({
+				meetingId: input.meetingId,
+				characterId: 'meeting-narrative-context',
+				prompt: buildNarrativeContextPrompt(input),
+				contextMessages: []
+			});
+		} catch {
+			return fallbackNarrativeContext(input);
+		}
 
 		if (!generated.ok) {
 			return fallbackNarrativeContext(input);
@@ -202,7 +218,10 @@ export async function getMeetingNarrativeContext(
 
 	try {
 		const resolved = await pending;
-		meetingNarrativeContextCache.set(input.meetingId, resolved);
+		meetingNarrativeContextCache.set(input.meetingId, {
+			value: resolved,
+			expiresAt: resolved.source === 'generated' ? null : Date.now() + FALLBACK_CACHE_TTL_MS
+		});
 		return resolved;
 	} finally {
 		meetingNarrativeContextInFlight.delete(input.meetingId);


### PR DESCRIPTION
## Summary
- catch thrown `generateShare` failures in `getMeetingNarrativeContext`
- add short-lived fallback cache semantics so transient failures do not permanently mask recovery
- add focused coverage for thrown generator failures and fallback TTL retry behavior

## Why
Issue #10 called out two resilience gaps in `narrative-context`:
1. thrown generator errors bypassed the normal SeamResult fallback path
2. fallback-generated context could linger too long and hide upstream recovery

This keeps the fix narrow and inside the existing core module instead of spreading retry logic into routes.

## Verification
- direct module probe via `node --import tsx` confirmed:
  - thrown generator errors return fallback context
  - fallback context is reused before TTL expiry
  - generation retries after TTL expiry and upgrades to generated context
- attempted `vitest` and `npm run build`, but the current repo-level tooling hung/timed out in this environment even on narrow runs, so I am not overstating those as green

## Notes
- fallback TTL is currently 30s as a small, explicit compromise between retry spam and permanently stale cache state

## Summary by Sourcery

Harden meeting narrative context generation to handle generator failures and add expiry semantics for fallback context caching.

Bug Fixes:
- Ensure thrown errors from the underlying narrative generator return fallback narrative context instead of failing silently or bypassing the normal fallback path.
- Prevent fallback-generated narrative context from persisting indefinitely by expiring it after a short TTL so upstream recovery can be observed.

Enhancements:
- Introduce TTL-aware caching for meeting narrative context, keeping generated results indefinitely while allowing fallback results to expire and be regenerated.
- Adjust narrative context caching logic to store additional metadata alongside cached values, enabling expiration checks.

Tests:
- Extend narrative context tests to cover thrown generator failures and verify fallback behavior, including reuse before TTL expiry and regeneration after expiry.
- Use fake timers in tests to simulate fallback cache TTL and validate retry behavior without relying on real time.