### PR TITLE
fix(meeting): restore persisted room-led meeting flow

### DIFF
--- a/CATCHUP_NOTE_2026-03-19.md
+++ b/CATCHUP_NOTE_2026-03-19.md
@@ -1,0 +1,83 @@
+# Catch-Up Note - 2026-03-19
+
+This is the fastest way to get back into the project without rereading the whole thread.
+
+## Current Truth
+
+- The app code is not currently the main blocker.
+- The live production site is still pointed at a dead Supabase tenant.
+- The current dead project ref is `tmcpfhftdrexsjrcrxbo`.
+- Both Vercel projects, `app` and `the14thstep`, were configured with that same stale backend.
+- That means the Vercel project/domain switch did not cut off a healthy database. It carried forward an already-dead database config.
+
+## What We Proved
+
+- `SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_URL` both point to `https://tmcpfhftdrexsjrcrxbo.supabase.co`.
+- That host does not resolve.
+- All three production Postgres URLs tied to that same tenant fail with `Tenant or user not found`.
+- The remaining production failure is therefore an infrastructure/backend problem, not a prompt problem and not an auth/UI problem.
+- Clerk cookie handling was still worth fixing, and that fix was real, but it was not the final production blocker.
+
+## What Already Landed
+
+- PR `#68` merged: Clerk member session cookie handling fix.
+- PR `#69` merged: Clerk cookie selection hardening follow-up.
+- Room-led meeting flow work is already on `main`.
+
+## What Is Open
+
+- PR `#70` is open as a draft:
+  - `fix(core): harden narrative context fallback handling`
+- Issue `#71` is open:
+  - restore production database backend after dead Supabase tenant outage
+
+## Why Production Is Still Broken
+
+The site can load, but meeting start still fails because the server cannot talk to a real backend. The current Supabase tenant appears gone, and the corresponding Postgres credentials also appear dead. There is no honest app-side shortcut that restores production without reconnecting the app to a real database target.
+
+## No-Shortcuts Fix
+
+Because old production data does not matter, the proper fix is:
+
+1. Create a fresh Supabase project.
+2. Apply the existing schema/migrations from [app/supabase/migrations](/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/app/supabase/migrations).
+3. Update the live Vercel `app` project env vars to the new Supabase project.
+4. Redeploy.
+5. Verify guest meeting start, member meeting start, and actual room behavior on the real site.
+
+## Why We Did Not Keep Patching
+
+We explicitly rejected the following because they would add debt:
+
+- route-level workarounds
+- in-memory production fallback
+- partial database bypasses
+- speculative adapter rewrites against dead production credentials
+- pretending the problem was auth-only after the backend evidence was clear
+
+## Exact Things To Reuse
+
+- Live recovery plan:
+  - [plans/production-recovery-and-backlog-execplan.md](/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/plans/production-recovery-and-backlog-execplan.md)
+- Lessons log:
+  - [LESSONS_LEARNED.md](/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/LESSONS_LEARNED.md)
+- Draft hardening PR:
+  - `#70`
+- Production blocker issue:
+  - `#71`
+
+## Important Repo/Branch State
+
+- Current branch when this note was written:
+  - `codex/production-db-recovery-2026-03-18`
+- That branch contains the blocker documentation, not the production fix.
+- The production fix itself has not happened yet because the real next step is a new database target.
+
+## Best Resume Point
+
+If resuming cold, start with this question:
+
+`Do we now have a fresh Supabase project to wire into Vercel?`
+
+- If yes: do the no-shortcuts reconnect path.
+- If no: do not thrash on app code. Keep working only on independent backlog slices like PR `#70`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this repository are documented in this file.
 
+## [2026-03-19]
+
+### Added
+
+- Added the living ExecPlan `plans/restore-virtual-recovery-meeting-execplan.md` for restoring the meeting page from dashboard flow back to the original room-led meeting experience.
+
+### Changed
+
+- Captured restore-specific architecture decisions in `decision-log.md`, including persisted room roster ownership, `seat_order` for stable intro order, truthful interaction-type persistence, and explicit listening-only handling.
+- Recorded restore-planning lessons in `LESSONS_LEARNED.md` so future meeting-flow work does not repeat the same roster/persistence/contract mistakes.
+
 ## [2026-03-16]
 
 ### Added
@@ -373,6 +384,30 @@ All notable changes to this repository are documented in this file.
 - Post-integration validation passes with clean `svelte-check` and `75` passing unit tests (`npm run test:unit -- --run`).
 - After Milestone 5 closeout refactor, `npm run check` passes clean and unit suite passes with `77` tests.
 - After Milestone 6 closeout updates, `npm run check` passes clean and unit suite passes with `78` tests including continuity verification.
+
+## [2026-03-19]
+
+### Changed
+- Preserved `interactionType` end-to-end through the meeting seam, Supabase adapter, fixtures, and route handlers, including `hard_question` and `farewell`.
+- Added persisted meeting-roster loading/saving on the meeting page loader and a Supabase migration for `seat_order` plus expanded share interaction values.
+- Reworked the meeting share route so it uses the persisted roster, completes introductions against the full room, and stops auto-advancing sharing rounds before the user turn.
+- Replaced the meeting page dashboard with a room-led sequence pass: auto opening beats, introductions, room-led topic handoff, three-round flow, crisis interruption, closing, and post-meeting reflection.
+- Removed transcript-facing debug leakage from share cards and softened the input copy so the UI reads like a room instead of a form.
+- Added visitor narrative-field generation so the random room participants are valid prompt subjects instead of sparse placeholder profiles.
+- Added explicit topic-selection semantics in the share route: `standard` keeps the room in `topic_selection` for Marcus's ask, while `respond_to` acknowledges the chosen topic and advances to round one.
+
+### Fixed
+- `EMPTY_CHAIR` now routes to Chrystal's reading instead of Marcus.
+- Listening-only sessions no longer stall on the intro/topic controls; the room can keep moving without user clicks.
+- Meeting-roster persistence now fails closed instead of silently continuing with unsaved generated visitors.
+- Crisis now stops the sequence engine instead of letting queued room beats keep firing behind the intervention.
+- `Keep coming back` now renders as a ritual beat, the stray `Return to Meeting` control is gone, and the end state closes into reflection plus `New meeting`.
+- Topic selection now uses an explicit pick-then-confirm control instead of turning every option into an immediate commit button.
+
+### Verified
+- `npm run test:unit -- --run src/lib/core/character-selector.spec.ts src/lib/seams/database/contract.test.ts src/lib/server/seams/database/adapter.spec.ts src/lib/server/routes/meeting-page-load.spec.ts src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-ritual-phase.integration.spec.ts`
+- `timeout 180s npm run check` completed with `0 errors`; one file still reports 8 known Svelte rune warnings documented in `DEFERRED.md`.
+- `timeout 180s npx eslint src/routes/meeting/[id]/+page.svelte src/routes/meeting/[id]/share/+server.ts src/lib/components/MeetingCircle.svelte src/lib/components/MeetingReflection.svelte src/lib/components/SystemMessage.svelte src/lib/components/UserInput.svelte src/lib/core/character-selector.ts src/lib/core/character-selector.spec.ts src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-ritual-phase.integration.spec.ts`
 
 ## [2026-02-15]
 

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -1,0 +1,11 @@
+# Deferred Work
+
+Out-of-scope issues discovered while executing the active ExecPlan go here.
+
+Format:
+
+- `YYYY-MM-DD` — short description of the deferred issue and why it was deferred.
+
+- `2026-03-19` — Full replay-free refresh recovery for mid-round auto beats is still incomplete; the current persisted phase model does not encode enough substep detail to resume every in-flight room beat without a broader ritual-state expansion.
+- `2026-03-19` — Newcomer-specific spoken welcome before topic selection is still partly local UI text; making that fully room-led would require either an additional persisted intro/topic subphase or a richer topic-selection contract.
+- `2026-03-19` — The meeting page still emits Svelte 5 `state_referenced_locally` warnings from its intentional initial-snapshot setup; fixing that cleanly needs a focused rune-state cleanup pass rather than another ad hoc initialization rewrite.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -2,6 +2,47 @@
 
 This file captures practical lessons we want future work to reuse.
 
+## 2026-03-19 (Restore Planning)
+
+### Process
+
+- **A feel-heavy restore plan still has to be brutally concrete**: If the plan hand-waves schema, persistence, or route validation details, the executing agent will fill those gaps with shortcuts.
+- **Self-contained ExecPlans beat elegant ones**: If a stateless agent needs the original chat prompt to understand the plan, the plan is not done.
+
+### Technical
+
+- **Random room participants need a real persistence model**: In this repo that means persisted participant rows plus stable seat order, not client-only shuffles.
+- **New share interaction types are not real until the whole stack agrees**: Core union, route validation, seam contract, adapter mapping, and database constraint all have to line up.
+- **Listening-only is easy to regress during meeting-flow rewrites**: It is mostly “skip this gate” logic, which means it disappears unless it is named explicitly in the plan and tests.
+
+## 2026-03-19
+
+### Process
+
+- **When production feels mysteriously “disconnected,” verify the infrastructure before rewriting code**: In this case the app still expected Supabase, Vercel still had Supabase env vars, and the real problem was that both Vercel projects were pointed at the same dead backend tenant.
+- **Blocked production time should still produce clean forward motion**: Merging the small auth hardening slice and opening a bounded narrative-context hardening PR was better than forcing speculative production code while the real backend remained unavailable.
+- **Write the catch-up note while the picture is fresh**: Once the diagnosis spans Vercel project links, stale env vars, merged PRs, blocked infra, and future slices, a single current-state memo is more valuable than expecting anyone to reconstruct the story from chat.
+
+### Technical
+
+- **A project switch is not automatically the cause of a backend outage**: The healthy `app` Vercel project and the old `the14thstep` project both carried the same stale Supabase ref, so moving aliases/projects did not sever a live database. It preserved an already-broken backend config.
+- **A DNS-resolvable Postgres host is not enough**: The pooler hostname can resolve while the tenant behind every Postgres URL is still dead. Probing all configured Postgres URLs matters before attempting a seam-level transport rewrite.
+- **If old data does not matter, fresh backend reprovision is cleaner than speculative adapter work**: Reconnecting the app to a new Supabase project and replaying the existing migrations is less debt than building a new production adapter against dead credentials just to avoid creating a replacement backend.
+
+## 2026-03-19 (Room Restore Execution)
+
+### Process
+
+- **A harsh re-audit after the first frontend pass is worth it**: The initial room-led rewrite looked plausibly done, but the critique step exposed exactly where the page was still cheating: crisis continuation, listening-only shortcuts, topic handoff drift, and dead-end refresh behavior.
+- **Backend truth beats frontend elegance when a room sequence needs to feel real**: The cleanest fixes came from making the server distinguish topic ask vs topic acknowledgment and from letting persisted phase state drive the page, not from layering more client-only choreography on top.
+
+### Technical
+
+- **One persisted phase can still hold two beats if the route understands interaction type**: `TOPIC_SELECTION` only became honest once `standard` meant “Marcus sets the topic in the room” and `respond_to` meant “Marcus acknowledges the chosen topic and moves the room forward.”
+- **Generated visitor characters need full narrative fields, not just names and colors**: Otherwise they degrade prompt quality exactly when the room is trying to feel most alive.
+- **Crisis interruption is not complete until the sequence engine stops advancing**: It is not enough to render the crisis response inline; the page must cancel the active share stream, clear pending user-turn continuations, and refuse to fire the next scheduled room beat.
+- **Svelte 5 rune warnings are easy to tolerate and still worth logging explicitly**: They are not blocking errors here, but leaving them unnamed makes later state bugs harder to triage because the meeting page already has noisy initialization semantics.
+
 ## 2026-03-14
 
 ### Process
@@ -178,3 +219,12 @@ This file captures practical lessons we want future work to reuse.
 ### Technical
 - Existing `node_modules` from another platform can break local test runs; a clean `npm install` fixed missing Linux-native Rollup binaries.
 - Lint tooling can behave differently from tests/checks in this environment, so verification should include multiple commands and timeout-aware triage.
+
+## 2026-03-19
+
+### Technical
+- The meeting phase machine must advance sharing rounds on the user turn, not on the second character share. If the share route advances early, the room stops feeling like a meeting and starts skipping over the user.
+- A persisted meeting roster is only real if the loader refuses to continue when roster persistence fails. Quietly falling back to generated visitor IDs turns a state bug into long-term drift.
+- `interactionType` only matters if it survives every seam layer. Adding enum values without preserving them through fixtures, adapters, routes, and tests creates fake support that breaks the first time the UI leans on it.
+- The introductions gate has two separate shortcut risks: the share route can jump to topic selection when all characters have spoken, and the user-share route can do the same with a simplistic speaker-count rule. Both have to use the real introduction-completion logic or the room quietly stops waiting for the user.
+- Svelte 5 rune warnings about capturing `data` in state initializers are worth fixing early. They are easy to ignore, but they make it harder to tell whether later page bugs are real state mistakes or just noisy initialization patterns.

--- a/app/src/hooks.server.ts
+++ b/app/src/hooks.server.ts
@@ -20,6 +20,12 @@ function createUnavailableDatabaseAdapter(message: string): DatabasePort {
 		async appendShare() {
 			return err(SeamErrorCodes.UPSTREAM_UNAVAILABLE, message);
 		},
+		async saveMeetingParticipants() {
+			return err(SeamErrorCodes.UPSTREAM_UNAVAILABLE, message);
+		},
+		async getMeetingParticipants() {
+			return err(SeamErrorCodes.UPSTREAM_UNAVAILABLE, message);
+		},
 		async getHeavyMemory() {
 			return err(SeamErrorCodes.UPSTREAM_UNAVAILABLE, message);
 		},

--- a/app/src/lib/components/MeetingCircle.svelte
+++ b/app/src/lib/components/MeetingCircle.svelte
@@ -19,7 +19,6 @@
 </script>
 
 <section class="circle-panel" aria-label="Meeting circle">
-	<h2>The Circle</h2>
 	<ul>
 		{#each characters as character (character.id)}
 			<li class:active={activeCharacterId === character.id}>
@@ -37,18 +36,10 @@
 </section>
 
 <style>
-	.circle-panel h2 {
-		margin: 0;
-		font-size: 0.95rem;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: #ffdca2;
-	}
-
 	.circle-panel ul {
 		list-style: none;
 		padding: 0;
-		margin: 0.72rem 0 0;
+		margin: 0;
 		display: grid;
 		gap: 0.45rem;
 	}

--- a/app/src/lib/components/MeetingReflection.svelte
+++ b/app/src/lib/components/MeetingReflection.svelte
@@ -1,17 +1,10 @@
 <script lang="ts">
-	let {
-		summary,
-		onClose
-	}: {
-		summary: string;
-		onClose?: () => void;
-	} = $props();
+	let { summary }: { summary: string } = $props();
 </script>
 
 <section class="reflection-shell" aria-live="polite">
 	<h2>Meeting Reflection</h2>
 	<p>{summary}</p>
-	<button type="button" onclick={() => onClose?.()}>Return to Meeting</button>
 </section>
 
 <style>
@@ -33,19 +26,5 @@
 		line-height: 1.55;
 		font-size: 0.93rem;
 		color: #fef3c7;
-	}
-
-	button {
-		margin-top: 0.72rem;
-		min-height: 2.6rem;
-		padding: 0.58rem 0.78rem;
-		font: inherit;
-		font-size: 0.84rem;
-		font-weight: 700;
-		border-radius: 0.66rem;
-		border: 1px solid rgba(251, 191, 36, 0.52);
-		background: rgba(180, 83, 9, 0.85);
-		color: #fff7e7;
-		cursor: pointer;
 	}
 </style>

--- a/app/src/lib/components/ShareMessage.svelte
+++ b/app/src/lib/components/ShareMessage.svelte
@@ -37,15 +37,13 @@
 			aria-expanded={isExpanded}
 			aria-controls={expandedRegionId}
 		>
-			{expanding ? 'Expanding...' : isExpanded ? 'Expanded' : 'Expand'}
+			{expanding ? 'Listening...' : isExpanded ? 'Told me more' : 'Tell me more'}
 		</button>
 	{/if}
 
 	{#if expandedText}
 		<p id={expandedRegionId} class="expanded">{expandedText}</p>
 	{/if}
-
-	<p class="meta">Significance {entry.significanceScore} · #{entry.sequenceOrder}</p>
 </li>
 
 <style>
@@ -67,7 +65,9 @@
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		color: #ffd59d;
-		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+		font-family:
+			ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+			monospace;
 	}
 
 	.body {
@@ -104,11 +104,5 @@
 		color: #ede9fe;
 		font-size: 0.88rem;
 		line-height: 1.45;
-	}
-
-	.meta {
-		margin: 0.55rem 0 0;
-		font-size: 0.72rem;
-		color: #9db0d4;
 	}
 </style>

--- a/app/src/lib/components/SystemMessage.svelte
+++ b/app/src/lib/components/SystemMessage.svelte
@@ -4,13 +4,14 @@
 		kind = 'info'
 	}: {
 		message: string;
-		kind?: 'info' | 'error' | 'success';
+		kind?: 'info' | 'error' | 'success' | 'ritual';
 	} = $props();
 
 	const styleMap = {
 		info: 'info',
 		error: 'error',
-		success: 'success'
+		success: 'success',
+		ritual: 'ritual'
 	} as const;
 </script>
 
@@ -47,5 +48,14 @@
 		border-color: rgba(110, 231, 183, 0.45);
 		background: rgba(19, 78, 56, 0.26);
 		color: #d1fae5;
+	}
+
+	.system-message.ritual {
+		border-color: rgba(245, 158, 11, 0.58);
+		background: rgba(120, 53, 15, 0.28);
+		color: #fde68a;
+		font-weight: 700;
+		text-align: center;
+		letter-spacing: 0.05em;
 	}
 </style>

--- a/app/src/lib/components/UserInput.svelte
+++ b/app/src/lib/components/UserInput.svelte
@@ -22,20 +22,22 @@
 	{#if listeningOnly}
 		<p class="listening-note">Listening mode enabled. Keep the room open and receive shares.</p>
 	{:else}
-		<label for="user-share">Your Share</label>
 		<textarea
 			id="user-share"
 			rows="5"
-			value={value}
+			{value}
 			oninput={(event) => onValueChange((event.currentTarget as HTMLTextAreaElement).value)}
-			placeholder={crisisMode ? "Take your time. We're here." : 'Type your share...'}
-			disabled={disabled}
+			placeholder={crisisMode ? "Take your time. We're here." : "Say what's true."}
+			{disabled}
 		></textarea>
 		<div class="actions">
-			<button type="button" onclick={onSubmit} disabled={disabled || !value.trim()} class="submit-btn">
-				Submit Share
-			</button>
-			<button type="button" onclick={onPass} disabled={disabled} class="pass-btn">Pass</button>
+			<button
+				type="button"
+				onclick={onSubmit}
+				disabled={disabled || !value.trim()}
+				class="submit-btn">Share</button
+			>
+			<button type="button" onclick={onPass} {disabled} class="pass-btn">Pass</button>
 		</div>
 	{/if}
 </section>
@@ -44,14 +46,6 @@
 	.input-shell {
 		display: grid;
 		gap: 0.52rem;
-	}
-
-	label {
-		font-size: 0.74rem;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		font-weight: 700;
-		color: #ffd7a0;
 	}
 
 	textarea {

--- a/app/src/lib/core/character-selector.spec.ts
+++ b/app/src/lib/core/character-selector.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { CORE_CHARACTERS } from './characters';
 import { selectCharacters } from './character-selector';
+import { validateCharacterNarrativeFields } from './characters';
 import type { CharacterProfile } from './types';
 
 const regulars: CharacterProfile[] = [
@@ -55,6 +56,20 @@ describe('selectCharacters', () => {
 		const selected = selectCharacters({ availableCharacters: [...CORE_CHARACTERS, ...regulars] });
 		const marcus = selected.find((character) => character.id === 'marcus');
 		expect(marcus?.role).toBe('chair');
+	});
+
+	it('gives generated visitors full narrative fields for prompting', () => {
+		const selected = selectCharacters({
+			availableCharacters: [...CORE_CHARACTERS, ...regulars],
+			random: () => 0.35,
+			nowIso: '2026-02-16T00:00:00.000Z'
+		});
+		const visitors = selected.filter((character) => character.isVisitor);
+
+		expect(visitors).toHaveLength(2);
+		for (const visitor of visitors) {
+			expect(validateCharacterNarrativeFields(visitor).ok).toBe(true);
+		}
 	});
 
 	it('fills additional seats from regular/pool when target size is larger', () => {

--- a/app/src/lib/core/character-selector.ts
+++ b/app/src/lib/core/character-selector.ts
@@ -4,13 +4,16 @@ import {
 	VISITOR_CLEAN_TIMES,
 	VISITOR_COLORS,
 	VISITOR_CONTRADICTIONS,
+	VISITOR_DISCOMFORT_REGISTERS,
+	VISITOR_LIES,
+	VISITOR_LOST_THINGS,
 	VISITOR_NAME_POOL,
+	VISITOR_PROGRAM_RELATIONSHIPS,
+	VISITOR_VOICE_EXAMPLE_SETS,
 	VISITOR_WOUNDS
 } from './characters';
-import type { CharacterProfile } from './types';
+import type { CharacterProfile, CharacterRole } from './types';
 import { bestEffortRandom } from './random-utils';
-
-export type CharacterRole = 'chair' | 'active_sharer' | 'quiet_presence';
 
 export interface SelectedCharacter extends CharacterProfile {
 	role: CharacterRole;
@@ -50,9 +53,45 @@ function visitorId(nowIso: string, index: number): string {
 	return `visitor-${nowIso.replace(/[^0-9]/g, '').slice(0, 14)}-${index}`;
 }
 
+function deriveVisitorCleanTimeStart(cleanTime: string, nowIso: string): Date {
+	const now = new Date(nowIso);
+	if (Number.isNaN(now.getTime())) {
+		return new Date();
+	}
+
+	if (cleanTime.startsWith('6 days')) {
+		now.setDate(now.getDate() - 6);
+		return now;
+	}
+
+	if (cleanTime.startsWith('19 days')) {
+		now.setDate(now.getDate() - 19);
+		return now;
+	}
+
+	if (cleanTime.startsWith('2 months')) {
+		now.setMonth(now.getMonth() - 2);
+		return now;
+	}
+
+	if (cleanTime.startsWith('9 months')) {
+		now.setMonth(now.getMonth() - 9);
+		return now;
+	}
+
+	if (cleanTime.includes('11 days')) {
+		now.setDate(now.getDate() - 11);
+		return now;
+	}
+
+	now.setDate(now.getDate() - 14);
+	return now;
+}
+
 function generateVisitors(random: () => number, nowIso: string): SelectedCharacter[] {
 	return [0, 1].map((index) => {
 		const name = pickOne(VISITOR_NAME_POOL, random);
+		const cleanTime = pickOne(VISITOR_CLEAN_TIMES, random);
 		return {
 			id: visitorId(nowIso, index),
 			name,
@@ -62,10 +101,16 @@ function generateVisitors(random: () => number, nowIso: string): SelectedCharact
 			wound: pickOne(VISITOR_WOUNDS, random),
 			contradiction: pickOne(VISITOR_CONTRADICTIONS, random),
 			voice: 'Concrete, specific, emotionally raw.',
+			voiceExamples: [...pickOne(VISITOR_VOICE_EXAMPLE_SETS, random)] as [string, string, string],
+			lie: pickOne(VISITOR_LIES, random),
+			discomfortRegister: pickOne(VISITOR_DISCOMFORT_REGISTERS, random),
+			programRelationship: pickOne(VISITOR_PROGRAM_RELATIONSHIPS, random),
+			lostThing: pickOne(VISITOR_LOST_THINGS, random),
 			quirk: 'Looks down before saying hard truths.',
 			color: pickOne(VISITOR_COLORS, random),
 			avatar: name.slice(0, 2),
-			cleanTime: pickOne(VISITOR_CLEAN_TIMES, random),
+			cleanTime,
+			cleanTimeStart: deriveVisitorCleanTimeStart(cleanTime, nowIso),
 			meetingCount: 0,
 			lastSeenAt: null,
 			role: 'quiet_presence' as const,

--- a/app/src/lib/core/characters.ts
+++ b/app/src/lib/core/characters.ts
@@ -216,6 +216,57 @@ export const VISITOR_CLEAN_TIMES = [
 	'relapsed 11 days back'
 ] as const;
 
+export const VISITOR_LIES = [
+	'If I keep moving, nobody gets close enough to see how scared I am.',
+	'I can keep one foot out the door and still call this honest.',
+	'If I sound fine, maybe I do not have to admit how bad it got.',
+	'If I disappear first, nobody gets to leave me.'
+] as const;
+
+export const VISITOR_DISCOMFORT_REGISTERS = [
+	'Looks at the floor, starts twice, then says the part they were trying to skip.',
+	'Laughs once with no joy in it, then grips the coffee cup harder.',
+	'Voice gets flatter the closer they get to the truth.',
+	'Shoulders tense, eyes drift to the door, then they stay and finish the sentence.'
+] as const;
+
+export const VISITOR_PROGRAM_RELATIONSHIPS = [
+	'Does not trust the room yet, but keeps showing up because being alone is worse.',
+	'Needs structure and hates needing it.',
+	'Still testing whether honesty here gets used against them.',
+	'Wants what the room has, resents how slowly it comes.'
+] as const;
+
+export const VISITOR_LOST_THINGS = [
+	'custody time, steady sleep, and the feeling of being welcome at home',
+	'a job they liked, people who answered the phone, and any clean sense of time',
+	'trust from family, a place to land, and the story they told about who they were',
+	'months they cannot get back and the version of them that used to feel easy'
+] as const;
+
+export const VISITOR_VOICE_EXAMPLE_SETS = [
+	[
+		'I keep saying I am fine like that word still means something.',
+		'I know exactly where the lie starts and I still catch myself halfway through it.',
+		'I came in here wanting to leave and I am still here, so that has to count for something.'
+	],
+	[
+		'Everybody says one day at a time and I am over here trying to survive the next hour.',
+		'I can hear myself making excuses while I am making them.',
+		'I do not need a miracle tonight. I need to not disappear.'
+	],
+	[
+		'I got real good at acting normal right up until my life fell through the floor.',
+		'I want help and I hate that those two words fit in the same mouth.',
+		'I am tired of calling fear a plan.'
+	],
+	[
+		'I keep showing up mad and somehow that still counts as showing up.',
+		'I know how to leave before anybody can ask the real question.',
+		'I am trying not to confuse shame with truth tonight.'
+	]
+] as const satisfies readonly [readonly [string, string, string], ...readonly [string, string, string][]];
+
 function isNonEmptyString(value: unknown): value is string {
 	return typeof value === 'string' && value.trim().length > 0;
 }

--- a/app/src/lib/core/meeting.spec.ts
+++ b/app/src/lib/core/meeting.spec.ts
@@ -48,6 +48,8 @@ function createDeps(overrides: Partial<MeetingWorkflowDeps> = {}): MeetingWorkfl
 				startedAt: '2026-02-16T00:00:00.000Z',
 				endedAt: null
 			}),
+		saveMeetingParticipants: async () => ok([]),
+		getMeetingParticipants: async () => ok([]),
 		appendShare: async (input) =>
 			ok<ShareRecord>({
 				id: 'share-1',
@@ -55,6 +57,7 @@ function createDeps(overrides: Partial<MeetingWorkflowDeps> = {}): MeetingWorkfl
 				characterId: input.characterId,
 				isUserShare: input.isUserShare,
 				content: input.content,
+				interactionType: input.interactionType,
 				significanceScore: input.significanceScore,
 				sequenceOrder: input.sequenceOrder,
 				createdAt: '2026-02-16T00:01:00.000Z'
@@ -67,6 +70,7 @@ function createDeps(overrides: Partial<MeetingWorkflowDeps> = {}): MeetingWorkfl
 				characterId: 'marcus',
 				isUserShare: false,
 				content: 'Share lookup',
+				interactionType: 'respond_to',
 				significanceScore: 6,
 				sequenceOrder: 1,
 				createdAt: '2026-02-16T00:01:00.000Z'

--- a/app/src/lib/core/meeting.ts
+++ b/app/src/lib/core/meeting.ts
@@ -2,15 +2,9 @@ import { SeamErrorCodes, err, ok, type SeamResult } from './seam';
 import type { DatabasePort, MeetingRecord, ShareRecord } from '$lib/seams/database/contract';
 import type { GrokAiPort } from '$lib/seams/grok-ai/contract';
 import { detectCrisisContent as detectCrisisContentFromEngine } from './crisis-engine';
+import type { ShareInteractionType } from './types';
 
-export type ShareInteractionType =
-	| 'standard'
-	| 'respond_to'
-	| 'disagree'
-	| 'parallel_story'
-	| 'expand'
-	| 'crosstalk'
-	| 'callback';
+export type { ShareInteractionType } from './types';
 
 export interface CreateMeetingInput {
 	userId: string;
@@ -142,7 +136,8 @@ export async function addShare(
 		isUserShare: input.isUserShare,
 		content: input.content,
 		significanceScore,
-		sequenceOrder: input.sequenceOrder
+		sequenceOrder: input.sequenceOrder,
+		interactionType: input.interactionType
 	});
 }
 

--- a/app/src/lib/core/memory-builder.spec.ts
+++ b/app/src/lib/core/memory-builder.spec.ts
@@ -11,6 +11,7 @@ const shares: ShareRecord[] = [
 		characterId: 'marcus',
 		isUserShare: false,
 		content: 'standard',
+		interactionType: 'standard',
 		significanceScore: 3,
 		sequenceOrder: 1,
 		createdAt: '2026-02-10T00:00:00.000Z'
@@ -21,6 +22,7 @@ const shares: ShareRecord[] = [
 		characterId: null,
 		isUserShare: true,
 		content: 'heavy user event',
+		interactionType: 'standard',
 		significanceScore: 6,
 		sequenceOrder: 2,
 		createdAt: '2026-02-11T00:00:00.000Z'
@@ -31,6 +33,7 @@ const shares: ShareRecord[] = [
 		characterId: 'heather',
 		isUserShare: false,
 		content: 'breakthrough',
+		interactionType: 'respond_to',
 		significanceScore: 8,
 		sequenceOrder: 3,
 		createdAt: '2026-02-12T00:00:00.000Z'
@@ -41,6 +44,7 @@ const shares: ShareRecord[] = [
 		characterId: 'gypsy',
 		isUserShare: false,
 		content: 'low score but in last meeting',
+		interactionType: 'standard',
 		significanceScore: 2,
 		sequenceOrder: 4,
 		createdAt: '2026-02-13T00:00:00.000Z'

--- a/app/src/lib/core/milestone6-continuity.spec.ts
+++ b/app/src/lib/core/milestone6-continuity.spec.ts
@@ -19,6 +19,7 @@ describe('milestone 6 continuity verification', () => {
 							characterId: 'marcus',
 							isUserShare: false,
 							content: 'I stayed and did not run this time.',
+							interactionType: 'respond_to',
 							significanceScore: 8,
 							sequenceOrder: 1,
 							createdAt: '2026-02-10T00:00:00.000Z'
@@ -29,6 +30,7 @@ describe('milestone 6 continuity verification', () => {
 							characterId: null,
 							isUserShare: true,
 							content: 'I came back tonight even though I wanted to hide.',
+							interactionType: 'standard',
 							significanceScore: 6,
 							sequenceOrder: 2,
 							createdAt: '2026-02-11T00:00:00.000Z'

--- a/app/src/lib/core/random-utils.ts
+++ b/app/src/lib/core/random-utils.ts
@@ -61,3 +61,20 @@ export function bestEffortRandomInt(maxExclusive: number): number {
 
 	return value % max;
 }
+
+function hashSeed(seed: string): number {
+	let hash = 2166136261;
+	for (let index = 0; index < seed.length; index += 1) {
+		hash ^= seed.charCodeAt(index);
+		hash = Math.imul(hash, 16777619);
+	}
+	return hash >>> 0;
+}
+
+export function createSeededRandom(seed: string): () => number {
+	let state = hashSeed(seed) || 1;
+	return () => {
+		state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+		return state / 4_294_967_296;
+	};
+}

--- a/app/src/lib/core/types.ts
+++ b/app/src/lib/core/types.ts
@@ -1,5 +1,6 @@
 export type CharacterTier = 'core' | 'regular' | 'pool' | 'visitor' | 'archived';
 export type CharacterStatus = 'active' | 'relapsed' | 'archived';
+export type CharacterRole = 'chair' | 'active_sharer' | 'quiet_presence';
 
 export type ShareInteractionType =
 	| 'standard'
@@ -8,7 +9,9 @@ export type ShareInteractionType =
 	| 'parallel_story'
 	| 'expand'
 	| 'crosstalk'
-	| 'callback';
+	| 'callback'
+	| 'hard_question'
+	| 'farewell';
 
 export type CallbackType =
 	| 'self_deprecation'
@@ -50,6 +53,13 @@ interface CharacterProfileBase {
 export interface CharacterProfile extends CharacterProfileBase, Partial<CharacterNarrativeProfile> {}
 
 export type CoreCharacterProfile = CharacterProfile & CharacterNarrativeProfile & { tier: 'core' };
+
+export interface MeetingParticipant extends CharacterProfile {
+	role: CharacterRole;
+	isVisitor: boolean;
+	seatOrder: number;
+	sharesCount: number;
+}
 
 export interface MemoryShare {
 	id: string;

--- a/app/src/lib/seams/database/contract.test.ts
+++ b/app/src/lib/seams/database/contract.test.ts
@@ -8,6 +8,8 @@ import {
 	validateGetMeetingCountAfterDateInput,
 	validateAppendShareInput,
 	validateEnsureUserProfileInput,
+	validateMeetingParticipant,
+	validateMeetingParticipantSeed,
 	validateMeetingRecord,
 	validateShareRecord,
 	validateUpdateCallbackInput,
@@ -20,6 +22,7 @@ import createMeetingSample from './fixtures/createMeeting.sample.json';
 import faultFixture from './fixtures/fault.json';
 import getActiveCallbacksSample from './fixtures/getActiveCallbacks.sample.json';
 import getHeavyMemorySample from './fixtures/getHeavyMemory.sample.json';
+import getMeetingParticipantsSample from './fixtures/getMeetingParticipants.sample.json';
 import getShareByIdSample from './fixtures/getShareById.sample.json';
 import getUserByIdSample from './fixtures/getUserById.sample.json';
 
@@ -72,6 +75,15 @@ describe('database seam contract', () => {
 		expect(
 			(getActiveCallbacksSample as unknown[]).every((record) => validateCallbackRecord(record))
 		).toBe(true);
+		expect(
+			(getMeetingParticipantsSample as unknown[]).every((record) => validateMeetingParticipant(record))
+		).toBe(true);
+		expect(
+			(getMeetingParticipantsSample as unknown[]).every((record) => {
+				const { sharesCount: _sharesCount, ...seed } = record as Record<string, unknown>;
+				return validateMeetingParticipantSeed(seed);
+			})
+		).toBe(true);
 	});
 
 	it('mock returns fixture values exactly', async () => {
@@ -110,6 +122,7 @@ describe('database seam contract', () => {
 			characterId: 'marcus',
 			isUserShare: false,
 			content: 'Now I have learned to sit in a hard minute.',
+			interactionType: 'respond_to',
 			significanceScore: 7,
 			sequenceOrder: 4
 		});
@@ -128,6 +141,21 @@ describe('database seam contract', () => {
 		expect(shareById.ok).toBe(true);
 		if (shareById.ok) {
 			expect(shareById.value).toEqual(getShareByIdSample);
+		}
+
+		const participants = await mock.getMeetingParticipants('2f5dcf63-cf80-4e09-8e3e-13f93da72cf3');
+		expect(participants.ok).toBe(true);
+		if (participants.ok) {
+			expect(participants.value).toEqual(getMeetingParticipantsSample);
+		}
+
+		const savedParticipants = await mock.saveMeetingParticipants({
+			meetingId: '2f5dcf63-cf80-4e09-8e3e-13f93da72cf3',
+			participants: getMeetingParticipantsSample as unknown as import('./contract').MeetingParticipantSeed[]
+		});
+		expect(savedParticipants.ok).toBe(true);
+		if (savedParticipants.ok) {
+			expect(savedParticipants.value).toEqual(getMeetingParticipantsSample);
 		}
 
 		const callbacks = await mock.getActiveCallbacks({
@@ -170,6 +198,33 @@ describe('database seam contract', () => {
 		if (meetingCount.ok) {
 			expect(meetingCount.value).toBe(16);
 		}
+
+		const participantSeed = {
+			id: 'marcus',
+			name: 'Marcus',
+			tier: 'core' as const,
+			status: 'active' as const,
+			archetype: 'chair',
+			wound: 'grief',
+			contradiction: 'soft voice, hard edge',
+			voice: 'measured',
+			quirk: 'leans back before he speaks',
+			color: '#c58a31',
+			avatar: 'M',
+			cleanTime: '12 years',
+			meetingCount: 0,
+			lastSeenAt: null,
+			role: 'chair' as const,
+			isVisitor: false,
+			seatOrder: 0
+		};
+		expect(validateMeetingParticipantSeed(participantSeed)).toBe(true);
+		expect(
+			validateMeetingParticipant({
+				...participantSeed,
+				sharesCount: 1
+			})
+		).toBe(true);
 	});
 
 	it('mock can surface fault scenario per method', async () => {
@@ -195,6 +250,7 @@ describe('database seam contract', () => {
 				characterId: 'marcus',
 				isUserShare: false,
 				content: 'x',
+				interactionType: 'not_real',
 				significanceScore: 11,
 				sequenceOrder: 1
 			})

--- a/app/src/lib/seams/database/contract.ts
+++ b/app/src/lib/seams/database/contract.ts
@@ -1,4 +1,11 @@
-import type { MeetingPhaseState } from '$lib/core/types';
+import type {
+	CharacterRole,
+	CharacterStatus,
+	CharacterTier,
+	MeetingParticipant,
+	MeetingPhaseState,
+	ShareInteractionType
+} from '$lib/core/types';
 import { SeamErrorCodes, type SeamErrorCode, type SeamResult } from '$lib/core/seam';
 
 export interface UserProfile {
@@ -26,9 +33,30 @@ export interface ShareRecord {
 	characterId: string | null;
 	isUserShare: boolean;
 	content: string;
+	interactionType: ShareInteractionType;
 	significanceScore: number;
 	sequenceOrder: number;
 	createdAt: string;
+}
+
+export interface MeetingParticipantSeed {
+	id: string;
+	name: string;
+	tier: CharacterTier;
+	status: CharacterStatus;
+	archetype: string;
+	wound: string;
+	contradiction: string;
+	voice: string;
+	quirk: string;
+	color: string;
+	avatar: string;
+	cleanTime: string;
+	meetingCount: number;
+	lastSeenAt: string | null;
+	role: CharacterRole;
+	isVisitor: boolean;
+	seatOrder: number;
 }
 
 export type CallbackType =
@@ -101,6 +129,11 @@ export interface DatabasePort {
 		input: Omit<MeetingRecord, 'id' | 'startedAt' | 'endedAt'>
 	): Promise<SeamResult<MeetingRecord>>;
 	appendShare(input: Omit<ShareRecord, 'id' | 'createdAt'>): Promise<SeamResult<ShareRecord>>;
+	saveMeetingParticipants(input: {
+		meetingId: string;
+		participants: MeetingParticipantSeed[];
+	}): Promise<SeamResult<MeetingParticipant[]>>;
+	getMeetingParticipants(meetingId: string): Promise<SeamResult<MeetingParticipant[]>>;
 	getHeavyMemory(userId: string): Promise<SeamResult<ShareRecord[]>>;
 	getShareById(shareId: string): Promise<SeamResult<ShareRecord>>;
 	getMeetingShares(meetingId: string): Promise<SeamResult<ShareRecord[]>>;
@@ -137,6 +170,38 @@ function isNonEmptyString(value: unknown): value is string {
 
 function isNullableString(value: unknown): value is string | null {
 	return value === null || typeof value === 'string';
+}
+
+function isCharacterTier(value: unknown): value is CharacterTier {
+	return (
+		value === 'core' ||
+		value === 'regular' ||
+		value === 'pool' ||
+		value === 'visitor' ||
+		value === 'archived'
+	);
+}
+
+function isCharacterStatus(value: unknown): value is CharacterStatus {
+	return value === 'active' || value === 'relapsed' || value === 'archived';
+}
+
+function isCharacterRole(value: unknown): value is CharacterRole {
+	return value === 'chair' || value === 'active_sharer' || value === 'quiet_presence';
+}
+
+function isShareInteractionType(value: unknown): value is ShareInteractionType {
+	return (
+		value === 'standard' ||
+		value === 'respond_to' ||
+		value === 'disagree' ||
+		value === 'parallel_story' ||
+		value === 'expand' ||
+		value === 'crosstalk' ||
+		value === 'callback' ||
+		value === 'hard_question' ||
+		value === 'farewell'
+	);
 }
 
 function isCallbackType(value: unknown): value is CallbackType {
@@ -218,6 +283,7 @@ export function validateShareRecord(value: unknown): value is ShareRecord {
 		(value.characterId === null || isNonEmptyString(value.characterId)) &&
 		typeof value.isUserShare === 'boolean' &&
 		isNonEmptyString(value.content) &&
+		isShareInteractionType(value.interactionType) &&
 		Number.isInteger(significanceScore) &&
 		typeof significanceScore === 'number' &&
 		significanceScore >= 0 &&
@@ -240,6 +306,7 @@ export function validateAppendShareInput(
 		(value.characterId === null || isNonEmptyString(value.characterId)) &&
 		typeof value.isUserShare === 'boolean' &&
 		isNonEmptyString(value.content) &&
+		isShareInteractionType(value.interactionType) &&
 		Number.isInteger(significanceScore) &&
 		typeof significanceScore === 'number' &&
 		significanceScore >= 0 &&
@@ -247,6 +314,45 @@ export function validateAppendShareInput(
 		Number.isInteger(sequenceOrder) &&
 		typeof sequenceOrder === 'number' &&
 		sequenceOrder >= 0
+	);
+}
+
+export function validateMeetingParticipantSeed(value: unknown): value is MeetingParticipantSeed {
+	if (!isObject(value)) return false;
+	const meetingCount = value.meetingCount;
+	const seatOrder = value.seatOrder;
+	return (
+		isNonEmptyString(value.id) &&
+		isNonEmptyString(value.name) &&
+		isCharacterTier(value.tier) &&
+		isCharacterStatus(value.status) &&
+		isNonEmptyString(value.archetype) &&
+		isNonEmptyString(value.wound) &&
+		isNonEmptyString(value.contradiction) &&
+		isNonEmptyString(value.voice) &&
+		isNonEmptyString(value.quirk) &&
+		isNonEmptyString(value.color) &&
+		isNonEmptyString(value.avatar) &&
+		isNonEmptyString(value.cleanTime) &&
+		Number.isInteger(meetingCount) &&
+		typeof meetingCount === 'number' &&
+		meetingCount >= 0 &&
+		isNullableString(value.lastSeenAt) &&
+		isCharacterRole(value.role) &&
+		typeof value.isVisitor === 'boolean' &&
+		Number.isInteger(seatOrder) &&
+		typeof seatOrder === 'number' &&
+		seatOrder >= 0
+	);
+}
+
+export function validateMeetingParticipant(value: unknown): value is MeetingParticipant {
+	if (!validateMeetingParticipantSeed(value)) return false;
+	const participant = value as MeetingParticipant;
+	return (
+		typeof participant.sharesCount === 'number' &&
+		Number.isInteger(participant.sharesCount) &&
+		participant.sharesCount >= 0
 	);
 }
 

--- a/app/src/lib/seams/database/fixtures/appendShare.sample.json
+++ b/app/src/lib/seams/database/fixtures/appendShare.sample.json
@@ -4,6 +4,7 @@
   "characterId": "marcus",
   "isUserShare": false,
   "content": "Now I have learned to sit in a hard minute instead of blowing up my life over it.",
+  "interactionType": "respond_to",
   "significanceScore": 7,
   "sequenceOrder": 4,
   "createdAt": "2026-02-15T04:03:14.000Z"

--- a/app/src/lib/seams/database/fixtures/getHeavyMemory.sample.json
+++ b/app/src/lib/seams/database/fixtures/getHeavyMemory.sample.json
@@ -5,6 +5,7 @@
     "characterId": "heather",
     "isUserShare": false,
     "content": "Listen, I wanted to disappear this week, but I called somebody before I made it worse.",
+    "interactionType": "respond_to",
     "significanceScore": 8,
     "sequenceOrder": 5,
     "createdAt": "2026-02-15T04:04:45.000Z"
@@ -15,6 +16,7 @@
     "characterId": null,
     "isUserShare": true,
     "content": "I told my mom the truth for the first time and she still answered the phone.",
+    "interactionType": "standard",
     "significanceScore": 9,
     "sequenceOrder": 8,
     "createdAt": "2026-02-08T03:14:12.000Z"

--- a/app/src/lib/seams/database/fixtures/getMeetingParticipants.sample.json
+++ b/app/src/lib/seams/database/fixtures/getMeetingParticipants.sample.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "marcus",
+    "name": "Marcus",
+    "tier": "core",
+    "status": "active",
+    "archetype": "chairman with a scarred tenderness",
+    "wound": "Believes he has to hold the room together because nobody did it for him.",
+    "contradiction": "Gruff as hell, but he notices everything.",
+    "voice": "Short, grounded, slightly impatient, never theatrical.",
+    "quirk": "Rubs his thumb against the lip of the coffee cup before hard questions.",
+    "color": "amber",
+    "avatar": "M",
+    "cleanTime": "12 years",
+    "meetingCount": 214,
+    "lastSeenAt": "2026-03-18T20:20:00.000Z",
+    "role": "chair",
+    "isVisitor": false,
+    "seatOrder": 0,
+    "sharesCount": 2
+  },
+  {
+    "id": "7b2cb9c0-b1d1-4827-975d-5e96d28a8ef0",
+    "name": "Tasha",
+    "tier": "visitor",
+    "status": "active",
+    "archetype": "keeps it together until she absolutely can't",
+    "wound": "Still thinks needing people is the same thing as being weak.",
+    "contradiction": "Walked in guarded, keeps blurting out the truest thing in the room.",
+    "voice": "Concrete, specific, emotionally raw.",
+    "quirk": "Looks down before saying hard truths.",
+    "color": "rust",
+    "avatar": "TA",
+    "cleanTime": "17 days",
+    "meetingCount": 0,
+    "lastSeenAt": null,
+    "role": "quiet_presence",
+    "isVisitor": true,
+    "seatOrder": 7,
+    "sharesCount": 0
+  }
+]

--- a/app/src/lib/seams/database/fixtures/getShareById.sample.json
+++ b/app/src/lib/seams/database/fixtures/getShareById.sample.json
@@ -4,6 +4,7 @@
   "characterId": "marcus",
   "isUserShare": false,
   "content": "Now I have learned to sit in a hard minute instead of blowing up my life over it.",
+  "interactionType": "respond_to",
   "significanceScore": 7,
   "sequenceOrder": 4,
   "createdAt": "2026-02-15T04:03:14.000Z"

--- a/app/src/lib/seams/database/mock.ts
+++ b/app/src/lib/seams/database/mock.ts
@@ -6,6 +6,7 @@ import type {
 	DatabasePort,
 	EnsureUserProfileInput,
 	GetMeetingCountAfterDateInput,
+	MeetingParticipantSeed,
 	MeetingRecord,
 	ShareRecord,
 	UpdateCallbackInput,
@@ -17,6 +18,8 @@ import {
 	validateCreateCallbackInput,
 	validateEnsureUserProfileInput,
 	validateGetMeetingCountAfterDateInput,
+	validateMeetingParticipant,
+	validateMeetingParticipantSeed,
 	validateAppendShareInput,
 	validateCreateMeetingInput,
 	validateMeetingRecord,
@@ -24,12 +27,14 @@ import {
 	validateUpdateCallbackInput,
 	validateUserProfile
 } from './contract';
+import type { MeetingParticipant } from '$lib/core/types';
 import appendShareSample from './fixtures/appendShare.sample.json';
 import createCallbackSample from './fixtures/createCallback.sample.json';
 import createMeetingSample from './fixtures/createMeeting.sample.json';
 import faultFixture from './fixtures/fault.json';
 import getActiveCallbacksSample from './fixtures/getActiveCallbacks.sample.json';
 import getHeavyMemorySample from './fixtures/getHeavyMemory.sample.json';
+import getMeetingParticipantsSample from './fixtures/getMeetingParticipants.sample.json';
 import getShareByIdSample from './fixtures/getShareById.sample.json';
 import getUserByIdSample from './fixtures/getUserById.sample.json';
 
@@ -39,6 +44,8 @@ type DatabaseMethod =
 	| 'getUserById'
 	| 'createMeeting'
 	| 'appendShare'
+	| 'saveMeetingParticipants'
+	| 'getMeetingParticipants'
 	| 'getHeavyMemory'
 	| 'getShareById'
 	| 'getMeetingShares'
@@ -55,6 +62,7 @@ interface DatabaseMockOptions {
 		getUserById?: UserProfile;
 		createMeeting?: MeetingRecord;
 		appendShare?: ShareRecord;
+		meetingParticipants?: MeetingParticipant[];
 		getHeavyMemory?: ShareRecord[];
 		getShareById?: ShareRecord;
 		getMeetingShares?: ShareRecord[];
@@ -95,6 +103,8 @@ export function createDatabaseMock(options: DatabaseMockOptions = {}): DatabaseP
 		getUserById: (options.fixtures?.getUserById ?? getUserByIdSample) as UserProfile,
 		createMeeting: (options.fixtures?.createMeeting ?? createMeetingSample) as MeetingRecord,
 		appendShare: (options.fixtures?.appendShare ?? appendShareSample) as ShareRecord,
+		meetingParticipants: (options.fixtures?.meetingParticipants ??
+			getMeetingParticipantsSample) as MeetingParticipant[],
 		getHeavyMemory: (options.fixtures?.getHeavyMemory ?? getHeavyMemorySample) as ShareRecord[],
 		getShareById: (options.fixtures?.getShareById ?? getShareByIdSample) as ShareRecord,
 		getMeetingShares: (options.fixtures?.getMeetingShares ?? getHeavyMemorySample) as ShareRecord[],
@@ -159,6 +169,37 @@ export function createDatabaseMock(options: DatabaseMockOptions = {}): DatabaseP
 				return err(SeamErrorCodes.CONTRACT_VIOLATION, 'Fixture violates ShareRecord');
 			}
 			return ok(fixtures.appendShare);
+		},
+
+		async saveMeetingParticipants(input: { meetingId: string; participants: MeetingParticipantSeed[] }) {
+			if (
+				typeof input.meetingId !== 'string' ||
+				input.meetingId.trim().length === 0 ||
+				!Array.isArray(input.participants) ||
+				!input.participants.every((participant) => validateMeetingParticipantSeed(participant))
+			) {
+				return err(SeamErrorCodes.INPUT_INVALID, 'Invalid saveMeetingParticipants input');
+			}
+			if (scenarios.saveMeetingParticipants === 'fault') {
+				return err(fault.code, fault.message, fault.details);
+			}
+			if (!fixtures.meetingParticipants.every((participant) => validateMeetingParticipant(participant))) {
+				return err(SeamErrorCodes.CONTRACT_VIOLATION, 'Fixture violates MeetingParticipant[]');
+			}
+			return ok(fixtures.meetingParticipants);
+		},
+
+		async getMeetingParticipants(meetingId) {
+			if (typeof meetingId !== 'string' || meetingId.trim().length === 0) {
+				return err(SeamErrorCodes.INPUT_INVALID, 'Invalid meetingId');
+			}
+			if (scenarios.getMeetingParticipants === 'fault') {
+				return err(fault.code, fault.message, fault.details);
+			}
+			if (!fixtures.meetingParticipants.every((participant) => validateMeetingParticipant(participant))) {
+				return err(SeamErrorCodes.CONTRACT_VIOLATION, 'Fixture violates MeetingParticipant[]');
+			}
+			return ok(fixtures.meetingParticipants);
 		},
 
 		async getHeavyMemory(userId) {

--- a/app/src/lib/server/routes/meeting-close.spec.ts
+++ b/app/src/lib/server/routes/meeting-close.spec.ts
@@ -71,6 +71,7 @@ describe('POST /meeting/[id]/close', () => {
 									characterId: null,
 									isUserShare: true,
 									content: 'I am staying tonight.',
+									interactionType: 'standard',
 									significanceScore: 6,
 									sequenceOrder: 0,
 									createdAt: '2026-02-22T00:01:00.000Z'

--- a/app/src/lib/server/routes/meeting-crisis.spec.ts
+++ b/app/src/lib/server/routes/meeting-crisis.spec.ts
@@ -18,6 +18,7 @@ describe('POST /meeting/[id]/crisis', () => {
 					characterId: 'marcus',
 					isUserShare: false,
 					content: 'Marcus support response.',
+					interactionType: 'respond_to',
 					significanceScore: 10,
 					sequenceOrder: 1,
 					createdAt: '2026-02-19T00:00:00.000Z'
@@ -86,6 +87,7 @@ describe('POST /meeting/[id]/crisis', () => {
 				characterId: 'marcus',
 				isUserShare: false,
 				content: 'Marcus support response during closing.',
+				interactionType: 'respond_to',
 				significanceScore: 10,
 				sequenceOrder: 9,
 				createdAt: '2026-02-19T00:00:01.000Z'

--- a/app/src/lib/server/routes/meeting-page-load.spec.ts
+++ b/app/src/lib/server/routes/meeting-page-load.spec.ts
@@ -1,6 +1,39 @@
 import { describe, expect, it } from 'vitest';
 import { load } from '../../../routes/meeting/[id]/+page.server';
 
+function createDatabaseStub(overrides: Record<string, unknown> = {}) {
+	const persistedParticipants = [
+		{
+			id: 'marcus',
+			name: 'Marcus',
+			tier: 'core' as const,
+			status: 'active' as const,
+			archetype: 'chair',
+			wound: 'grief',
+			contradiction: 'soft voice, hard edge',
+			voice: 'measured',
+			quirk: 'leans back before he speaks',
+			color: '#c58a31',
+			avatar: 'M',
+			cleanTime: '12 years',
+			meetingCount: 0,
+			lastSeenAt: null,
+			role: 'chair' as const,
+			isVisitor: false,
+			seatOrder: 0,
+			sharesCount: 0
+		}
+	];
+
+	return {
+		getMeetingShares: async () => ({ ok: true, value: [] }),
+		getMeetingPhase: async () => ({ ok: true, value: null }),
+		getMeetingParticipants: async () => ({ ok: true, value: [] }),
+		saveMeetingParticipants: async (_input: unknown) => ({ ok: true, value: persistedParticipants }),
+		...overrides
+	};
+}
+
 describe('meeting page server load', () => {
 	it('flags initial crisis mode when setup mind text has crisis keywords', async () => {
 		const result = await load({
@@ -8,10 +41,7 @@ describe('meeting page server load', () => {
 			locals: {
 				userId: 'user-1',
 				seams: {
-					database: {
-						getMeetingShares: async () => ({ ok: true, value: [] }),
-						getMeetingPhase: async () => ({ ok: true, value: null })
-					}
+					database: createDatabaseStub()
 				}
 			},
 			url: new URL('http://localhost/meeting/meeting-1?mind=I%20want%20to%20die')
@@ -29,10 +59,7 @@ describe('meeting page server load', () => {
 			locals: {
 				userId: 'user-1',
 				seams: {
-					database: {
-						getMeetingShares: async () => ({ ok: true, value: [] }),
-						getMeetingPhase: async () => ({ ok: true, value: null })
-					}
+					database: createDatabaseStub()
 				}
 			},
 			url: new URL('http://localhost/meeting/meeting-1?mind=Staying%20for%20the%20next%2024%20hours')
@@ -47,7 +74,7 @@ describe('meeting page server load', () => {
 			locals: {
 				userId: 'user-1',
 				seams: {
-					database: {
+					database: createDatabaseStub({
 						getMeetingShares: async () =>
 							({
 								ok: true,
@@ -58,14 +85,14 @@ describe('meeting page server load', () => {
 										characterId: null,
 										isUserShare: true,
 										content: 'I want to die tonight',
+										interactionType: 'standard',
 										significanceScore: 10,
 										sequenceOrder: 1,
 										createdAt: '2026-02-19T00:00:00.000Z'
 									}
 								]
-							}) as never,
-						getMeetingPhase: async () => ({ ok: true, value: null })
-					}
+							}) as never
+					})
 				}
 			},
 			url: new URL('http://localhost/meeting/meeting-1?mind=staying%20present')
@@ -83,8 +110,7 @@ describe('meeting page server load', () => {
 			locals: {
 				userId: 'user-1',
 				seams: {
-					database: {
-						getMeetingShares: async () => ({ ok: true, value: [] }),
+					database: createDatabaseStub({
 						getMeetingPhase: async () => ({
 							ok: true,
 							value: {
@@ -95,7 +121,7 @@ describe('meeting page server load', () => {
 								userHasSharedInRound: true
 							}
 						})
-					}
+					})
 				}
 			},
 			url: new URL('http://localhost/meeting/meeting-1?mind=staying%20present')
@@ -114,13 +140,12 @@ describe('meeting page server load', () => {
 				locals: {
 					userId: 'user-1',
 					seams: {
-						database: {
-							getMeetingShares: async () => ({ ok: true, value: [] }),
+						database: createDatabaseStub({
 							getMeetingPhase: async () => ({
 								ok: false,
 								error: { code: 'NOT_FOUND', message: 'missing' }
 							})
-						}
+						})
 					}
 				},
 				url: new URL('http://localhost/meeting/missing-meeting?mind=staying%20present')

--- a/app/src/lib/server/routes/meeting-ritual-phase.integration.spec.ts
+++ b/app/src/lib/server/routes/meeting-ritual-phase.integration.spec.ts
@@ -4,6 +4,7 @@ import type { MeetingPhaseState } from '$lib/core/types';
 import type {
 	CallbackRecord,
 	DatabasePort,
+	MeetingParticipantSeed,
 	MeetingRecord,
 	ShareRecord,
 	UserProfile
@@ -19,6 +20,7 @@ function makeShareRecord(input: {
 	characterId: string | null;
 	isUserShare: boolean;
 	content: string;
+	interactionType: ShareRecord['interactionType'];
 	significanceScore: number;
 	sequenceOrder: number;
 }): ShareRecord {
@@ -34,6 +36,7 @@ function createInMemoryDatabase(
 	const state = {
 		phaseState: null as MeetingPhaseState | null,
 		shares: [] as ShareRecord[],
+		participants: [] as Array<MeetingParticipantSeed & { sharesCount: number }>,
 		callbacks: [] as CallbackRecord[],
 		meeting: {
 			id: meetingId,
@@ -78,6 +81,16 @@ function createInMemoryDatabase(
 			};
 			return ok(state.meeting);
 		},
+		async saveMeetingParticipants(input) {
+			state.participants = input.participants.map((participant) => ({
+				...participant,
+				sharesCount: 0
+			}));
+			return ok(state.participants);
+		},
+		async getMeetingParticipants() {
+			return ok(state.participants);
+		},
 		async appendShare(input) {
 			const share = makeShareRecord({
 				id: `share-${state.shares.length + 1}`,
@@ -85,6 +98,7 @@ function createInMemoryDatabase(
 				characterId: input.characterId,
 				isUserShare: input.isUserShare,
 				content: input.content,
+				interactionType: input.interactionType,
 				significanceScore: input.significanceScore,
 				sequenceOrder: input.sequenceOrder
 			});
@@ -331,13 +345,14 @@ async function requestCharacterShare(input: {
 	grokAi: ReturnType<typeof createGrokStub>;
 	sequenceOrder: number;
 	characterId?: string;
+	interactionType?: ShareRecord['interactionType'];
 }) {
 	const url = new URL(`http://localhost/meeting/${input.meetingId}/share`);
 	url.searchParams.set('topic', 'staying');
 	url.searchParams.set('sequenceOrder', String(input.sequenceOrder));
 	url.searchParams.set('userName', 'You');
 	url.searchParams.set('userMood', 'raw');
-	url.searchParams.set('interactionType', 'respond_to');
+	url.searchParams.set('interactionType', input.interactionType ?? 'respond_to');
 	url.searchParams.set('crisisMode', '0');
 	if (input.characterId) url.searchParams.set('characterId', input.characterId);
 
@@ -387,6 +402,15 @@ describe('meeting ritual phase route integration (server routes + in-memory seam
 		const database = createInMemoryDatabase(meetingId);
 		const grokAi = createGrokStub();
 
+		await loadMeetingPage({
+			params: { id: meetingId },
+			locals: {
+				userId: 'user-1',
+				seams: { database, grokAi: grokAi as never, auth: {} as never }
+			},
+			url: new URL(`http://localhost/meeting/${meetingId}?mind=staying`)
+		} as never);
+
 		const events = await requestCharacterShare({
 			meetingId,
 			database,
@@ -411,7 +435,7 @@ describe('meeting ritual phase route integration (server routes + in-memory seam
 				seams: { database, grokAi: grokAi as never, auth: {} as never }
 			},
 			url: new URL(`http://localhost/meeting/${meetingId}?mind=staying`)
-		} as never)) as { phaseState: { currentPhase: string } };
+		} as never)) as { phaseState: { currentPhase: string }; characters: Array<{ id: string }> };
 		expect(initialLoad.phaseState.currentPhase).toBe('setup');
 
 		// SETUP -> OPENING -> EMPTY_CHAIR
@@ -432,67 +456,89 @@ describe('meeting ritual phase route integration (server routes + in-memory seam
 		});
 		expect(readPersistedPhase(events)).toBe('introductions');
 
-		// Introductions needs two speakers in current simplified route logic: user + character
+		let sequenceOrder = 2;
+		for (let index = 0; index < initialLoad.characters.length; index += 1) {
+			events = await requestCharacterShare({
+				meetingId,
+				database,
+				grokAi,
+				sequenceOrder
+			});
+			sequenceOrder += 1;
+		}
+
+		expect(readPersistedPhase(events)).toBe('introductions');
+
 		let userPayload = await requestUserShare({
 			meetingId,
 			database,
 			grokAi,
-			sequenceOrder: 2,
+			sequenceOrder,
 			content: 'I am here.'
 		});
 		expect(userPayload.ok).toBe(true);
-		expect(userPayload.value.phaseState.currentPhase).toBe('introductions');
+		expect(userPayload.value.phaseState.currentPhase).toBe('topic_selection');
+		sequenceOrder += 1;
 
+		// Topic selection first asks the room what is on the table, then acknowledges the chosen topic.
 		events = await requestCharacterShare({
 			meetingId,
 			database,
 			grokAi,
-			sequenceOrder: 3
+			sequenceOrder,
+			interactionType: 'standard'
 		});
 		expect(readPersistedPhase(events)).toBe('topic_selection');
+		sequenceOrder += 1;
 
-		// Topic selection -> sharing_round_1 on room-led topic introduction
 		events = await requestCharacterShare({
 			meetingId,
 			database,
 			grokAi,
-			sequenceOrder: 4
+			sequenceOrder,
+			interactionType: 'respond_to'
 		});
 		expect(readPersistedPhase(events)).toBe('sharing_round_1');
+		sequenceOrder += 1;
 
 		// Advance through sharing rounds with char+user pairs
-		events = await requestCharacterShare({ meetingId, database, grokAi, sequenceOrder: 5 });
+		events = await requestCharacterShare({ meetingId, database, grokAi, sequenceOrder });
 		expect(readPersistedPhase(events)).toBe('sharing_round_1');
+		sequenceOrder += 1;
 
 		userPayload = await requestUserShare({
 			meetingId,
 			database,
 			grokAi,
-			sequenceOrder: 6,
+			sequenceOrder,
 			content: 'still here'
 		});
 		expect(userPayload.value.phaseState.currentPhase).toBe('sharing_round_2');
+		sequenceOrder += 1;
 
-		events = await requestCharacterShare({ meetingId, database, grokAi, sequenceOrder: 7 });
+		events = await requestCharacterShare({ meetingId, database, grokAi, sequenceOrder });
 		expect(readPersistedPhase(events)).toBe('sharing_round_2');
+		sequenceOrder += 1;
 
 		userPayload = await requestUserShare({
 			meetingId,
 			database,
 			grokAi,
-			sequenceOrder: 8,
+			sequenceOrder,
 			content: 'still staying'
 		});
 		expect(userPayload.value.phaseState.currentPhase).toBe('sharing_round_3');
+		sequenceOrder += 1;
 
-		events = await requestCharacterShare({ meetingId, database, grokAi, sequenceOrder: 9 });
+		events = await requestCharacterShare({ meetingId, database, grokAi, sequenceOrder });
 		expect(readPersistedPhase(events)).toBe('sharing_round_3');
+		sequenceOrder += 1;
 
 		userPayload = await requestUserShare({
 			meetingId,
 			database,
 			grokAi,
-			sequenceOrder: 10,
+			sequenceOrder,
 			content: 'closing out'
 		});
 		expect(userPayload.value.phaseState.currentPhase).toBe('closing');

--- a/app/src/lib/server/routes/meeting-share.spec.ts
+++ b/app/src/lib/server/routes/meeting-share.spec.ts
@@ -1,7 +1,82 @@
 import { describe, expect, it } from 'vitest';
-import { POST } from '../../../routes/meeting/[id]/share/+server';
+import { CORE_CHARACTERS } from '$lib/core/characters';
+import { MeetingPhase } from '$lib/core/types';
+import { buildInteractionAwarePrompt, POST } from '../../../routes/meeting/[id]/share/+server';
 
 describe('POST /meeting/[id]/share', () => {
+	it('uses dedicated prompt builders for crosstalk, hard questions, and farewells', () => {
+		const heather = CORE_CHARACTERS.find((character) => character.id === 'heather')!;
+		const recentShares = [
+			{ speaker: 'Marcus', content: 'Stay in your chair.' },
+			{ speaker: 'You', content: 'I am trying not to run.' }
+		];
+		const recentTranscript = recentShares.map((share, index) => ({
+			...share,
+			isUserShare: index === 1
+		}));
+
+		const crosstalkPrompt = buildInteractionAwarePrompt(
+			heather,
+			MeetingPhase.SHARING_ROUND_1,
+			'crosstalk',
+			'Avery',
+			'raw',
+			'staying put',
+			recentShares,
+			recentTranscript
+		);
+		const hardQuestionPrompt = buildInteractionAwarePrompt(
+			heather,
+			MeetingPhase.SHARING_ROUND_2,
+			'hard_question',
+			'Avery',
+			'raw',
+			'staying put',
+			recentShares,
+			recentTranscript
+		);
+		const farewellPrompt = buildInteractionAwarePrompt(
+			heather,
+			MeetingPhase.POST_MEETING,
+			'farewell',
+			'Avery',
+			'raw',
+			'staying put',
+			recentShares,
+			recentTranscript
+		);
+
+		expect(crosstalkPrompt).toContain('one-sentence crosstalk reaction');
+		expect(crosstalkPrompt).toContain('Previous share: I am trying not to run.');
+		expect(hardQuestionPrompt).toContain('Write one hard but fair question for Avery.');
+		expect(hardQuestionPrompt).toContain('I am trying not to run.');
+		expect(farewellPrompt).toContain('gives one short goodbye to Avery');
+		expect(farewellPrompt).not.toContain('Recent room context');
+	});
+
+	it('uses the topic acknowledgment prompt when Marcus answers a chosen topic', () => {
+		const marcus = CORE_CHARACTERS.find((character) => character.id === 'marcus')!;
+		const recentShares = [{ speaker: 'You', content: 'I need to talk about staying.' }];
+		const recentTranscript = recentShares.map((share) => ({
+			...share,
+			isUserShare: true
+		}));
+
+		const topicAckPrompt = buildInteractionAwarePrompt(
+			marcus,
+			MeetingPhase.TOPIC_SELECTION,
+			'respond_to',
+			'Avery',
+			'raw',
+			'Staying clean when everything falls apart',
+			recentShares,
+			recentTranscript
+		);
+
+		expect(topicAckPrompt).toContain('Marcus acknowledges the selected topic.');
+		expect(topicAckPrompt).toContain('Topic: Staying clean when everything falls apart');
+	});
+
 	it('returns 409 when crisisMode is enabled', async () => {
 		const request = new Request('http://localhost/meeting/meeting-1/share', {
 			method: 'POST',
@@ -22,6 +97,7 @@ describe('POST /meeting/[id]/share', () => {
 				seams: {
 					database: {
 						getMeetingPhase: async () => ({ ok: true, value: null }),
+						getMeetingParticipants: async () => ({ ok: true, value: [] }),
 						getMeetingShares: async () =>
 							({
 								ok: true,
@@ -61,6 +137,7 @@ describe('POST /meeting/[id]/share', () => {
 				seams: {
 					database: {
 						getMeetingPhase: async () => ({ ok: true, value: null }),
+						getMeetingParticipants: async () => ({ ok: true, value: [] }),
 						getMeetingShares: async () =>
 							({
 								ok: true,
@@ -71,6 +148,7 @@ describe('POST /meeting/[id]/share', () => {
 										characterId: null,
 										isUserShare: true,
 										content: 'I want to die tonight',
+										interactionType: 'standard',
 										significanceScore: 10,
 										sequenceOrder: 1,
 										createdAt: '2026-02-19T00:00:00.000Z'
@@ -118,6 +196,7 @@ describe('POST /meeting/[id]/share', () => {
 								userHasSharedInRound: false
 							}
 						}),
+						getMeetingParticipants: async () => ({ ok: true, value: [] }),
 						getMeetingShares: async () => ({ ok: true, value: [] })
 					} as never,
 					grokAi: {} as never,
@@ -159,6 +238,7 @@ describe('POST /meeting/[id]/share', () => {
 								userHasSharedInRound: false
 							}
 						}),
+						getMeetingParticipants: async () => ({ ok: true, value: [] }),
 						getMeetingShares: async () => ({ ok: true, value: [] })
 					} as never,
 					grokAi: {} as never,
@@ -195,6 +275,7 @@ describe('POST /meeting/[id]/share', () => {
 							ok: false,
 							error: { code: 'NOT_FOUND', message: 'missing meeting' }
 						}),
+						getMeetingParticipants: async () => ({ ok: true, value: [] }),
 						getMeetingShares: async () => ({ ok: true, value: [] })
 					} as never,
 					grokAi: {} as never,

--- a/app/src/lib/server/routes/meeting-user-share.spec.ts
+++ b/app/src/lib/server/routes/meeting-user-share.spec.ts
@@ -17,6 +17,7 @@ describe('POST /meeting/[id]/user-share', () => {
 				characterId: null,
 				isUserShare: true,
 				content: 'I want to die tonight.',
+				interactionType: 'standard',
 				significanceScore: input.significanceScore,
 				sequenceOrder: 0,
 				createdAt: '2026-02-19T00:00:00.000Z'
@@ -73,6 +74,7 @@ describe('POST /meeting/[id]/user-share', () => {
 				characterId: null,
 				isUserShare: true,
 				content: 'I do not know what to do.',
+				interactionType: 'standard',
 				significanceScore: input.significanceScore,
 				sequenceOrder: 1,
 				createdAt: '2026-02-19T00:00:01.000Z'
@@ -128,6 +130,7 @@ describe('POST /meeting/[id]/user-share', () => {
 				characterId: null,
 				isUserShare: true,
 				content: 'I do not know if I can keep doing this.',
+				interactionType: 'standard',
 				significanceScore: input.significanceScore,
 				sequenceOrder: 2,
 				createdAt: '2026-02-19T00:00:01.500Z'
@@ -180,6 +183,7 @@ describe('POST /meeting/[id]/user-share', () => {
 				characterId: null,
 				isUserShare: true,
 				content: 'I had a rough night but I am here.',
+				interactionType: 'standard',
 				significanceScore: input.significanceScore,
 				sequenceOrder: 3,
 				createdAt: '2026-02-19T00:00:01.900Z'
@@ -232,6 +236,7 @@ describe('POST /meeting/[id]/user-share', () => {
 				characterId: null,
 				isUserShare: true,
 				content: 'I am not sure what happens next.',
+				interactionType: 'standard',
 				significanceScore: input.significanceScore,
 				sequenceOrder: 4,
 				createdAt: '2026-02-19T00:00:02.200Z'
@@ -282,6 +287,7 @@ describe('POST /meeting/[id]/user-share', () => {
 				characterId: null,
 				isUserShare: true,
 				content: 'I am staying with it.',
+				interactionType: 'standard',
 				significanceScore: 4,
 				sequenceOrder: 2,
 				createdAt: '2026-02-19T00:00:02.000Z'

--- a/app/src/lib/server/seams/database/adapter.spec.ts
+++ b/app/src/lib/server/seams/database/adapter.spec.ts
@@ -31,8 +31,12 @@ interface MockResponses {
 	meetingCountSelect?: QueryResponse;
 	shareSingle?: QueryResponse;
 	heavyMemorySelect?: QueryResponse;
+	meetingParticipantsMaybeSingle?: QueryResponse;
+	meetingParticipantsSelect?: QueryResponse;
+	meetingParticipantsInsert?: QueryResponse;
+	meetingParticipantsUpdateMaybeSingle?: QueryResponse;
 	// Optional specific rows to return from the characters mock instead of default generated ones
-	characterRows?: Array<{ id: string; name: string }>;
+	characterRows?: Array<{ id: string; name: string; intro_style?: string }>;
 	charactersSelect?: QueryResponse;
 	characterInsertSelect?: QueryResponse;
 }
@@ -68,10 +72,11 @@ function createCallbacksSelectChain(response: QueryResponse) {
 	};
 }
 
-function defaultCharacterRows(): Array<{ id: string; name: string }> {
+function defaultCharacterRows(): Array<{ id: string; name: string; intro_style: string }> {
 	return CORE_CHARACTERS.map((character, index) => ({
 		id: `00000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`,
-		name: character.name
+		name: character.name,
+		intro_style: character.id
 	}));
 }
 
@@ -105,6 +110,26 @@ function createHarness(responses: MockResponses = {}) {
 	};
 	const shareSingle = responses.shareSingle ?? { data: null, error: null, status: 200 };
 	const heavyMemorySelect = responses.heavyMemorySelect ?? { data: [], error: null, status: 200 };
+	const meetingParticipantsMaybeSingle = responses.meetingParticipantsMaybeSingle ?? {
+		data: null,
+		error: null,
+		status: 200
+	};
+	const meetingParticipantsSelect = responses.meetingParticipantsSelect ?? {
+		data: [],
+		error: null,
+		status: 200
+	};
+	const meetingParticipantsInsert = responses.meetingParticipantsInsert ?? {
+		data: [],
+		error: null,
+		status: 201
+	};
+	const meetingParticipantsUpdateMaybeSingle = responses.meetingParticipantsUpdateMaybeSingle ?? {
+		data: { meeting_id: 'meeting-1' },
+		error: null,
+		status: 200
+	};
 	const charactersSelect = responses.charactersSelect;
 	const characterInsertSelect = responses.characterInsertSelect;
 	const characterRows = [...(responses.characterRows ?? defaultCharacterRows())];
@@ -191,6 +216,40 @@ function createHarness(responses: MockResponses = {}) {
 				};
 			}
 
+			if (table === 'meeting_participants') {
+				return {
+					select: () => ({
+						eq: (_meetingColumn: string, meetingValue: string) => ({
+							eq: (_characterColumn: string, characterValue: string) => ({
+								maybeSingle: async () =>
+									responses.meetingParticipantsMaybeSingle ??
+									{
+										data:
+											(meetingParticipantsSelect.data as Array<Record<string, unknown>> | undefined)?.find(
+												(row) =>
+													row.meeting_id === meetingValue &&
+													row.character_id === characterValue
+											) ?? null,
+										error: null,
+										status: 200
+									}
+							}),
+							order: async () => meetingParticipantsSelect
+						})
+					}),
+					insert: () => meetingParticipantsInsert,
+					update: () => ({
+						eq: () => ({
+							eq: () => ({
+								select: () => ({
+									maybeSingle: async () => meetingParticipantsUpdateMaybeSingle
+								})
+							})
+						})
+					})
+				};
+			}
+
 			if (table === 'callbacks') {
 				return {
 					select: () => ({
@@ -230,7 +289,19 @@ function createHarness(responses: MockResponses = {}) {
 								error: null,
 								status: 200
 							};
-						}
+						},
+						eq: (_column: string, value: string) => ({
+							maybeSingle: async () => {
+								const match = characterRows.find(
+									(row) => row.intro_style === value || row.name === value
+								);
+								return {
+									data: match ?? null,
+									error: null,
+									status: 200
+								};
+							}
+						})
 					}),
 					insert: (payload: unknown) => {
 						const inserted =
@@ -242,11 +313,16 @@ function createHarness(responses: MockResponses = {}) {
 											const name = typeof record.name === 'string' ? record.name : null;
 											if (!name) return null;
 											const id = `10000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`;
-											const created = { id, name };
+											const introStyle =
+												typeof record.intro_style === 'string' ? record.intro_style : undefined;
+											const created = { id, name, intro_style: introStyle };
 											characterRows.push(created);
 											return created;
 										})
-										.filter((row): row is { id: string; name: string } => row !== null)
+										.filter(
+											(row): row is { id: string; name: string; intro_style: string | undefined } =>
+												row !== null
+										)
 								: [];
 
 						return {
@@ -369,6 +445,7 @@ describe('database supabase adapter', () => {
 			characterId: 'marcus',
 			isUserShare: false,
 			content: 'Now I can stay in the room.',
+			interactionType: 'respond_to',
 			significanceScore: 7,
 			sequenceOrder: 4
 		});
@@ -389,6 +466,7 @@ describe('database supabase adapter', () => {
 						character_id: 'heather',
 						is_user_share: false,
 						content: 'I called someone before I blew up my life.',
+						interaction_type: 'respond_to',
 						significance_score: 99,
 						sequence_order: 5,
 						created_at: '2026-02-15T04:04:45.000Z'
@@ -800,6 +878,7 @@ describe('database supabase adapter', () => {
 					character_id: marcusDbId,
 					is_user_share: false,
 					content: 'Now I can stay in the room.',
+					interaction_type: 'respond_to',
 					significance_score: 7,
 					sequence_order: 3,
 					created_at: '2026-02-15T04:00:00.000Z'
@@ -814,6 +893,7 @@ describe('database supabase adapter', () => {
 			characterId: 'marcus',
 			isUserShare: false,
 			content: 'Now I can stay in the room.',
+			interactionType: 'respond_to',
 			significanceScore: 7,
 			sequenceOrder: 3
 		});
@@ -848,6 +928,7 @@ describe('database supabase adapter', () => {
 			characterId: 'marcus',
 			isUserShare: false,
 			content: 'test',
+			interactionType: 'standard',
 			significanceScore: 5,
 			sequenceOrder: 1
 		});

--- a/app/src/lib/server/seams/database/adapter.ts
+++ b/app/src/lib/server/seams/database/adapter.ts
@@ -1,10 +1,11 @@
 import { SeamErrorCodes, err, ok, type SeamResult } from '$lib/core/seam';
 import { CORE_CHARACTERS } from '$lib/core/characters';
-import { MeetingPhase, type MeetingPhaseState } from '$lib/core/types';
+import { MeetingPhase, type MeetingParticipant, type MeetingPhaseState } from '$lib/core/types';
 import {
 	type CallbackRecord,
 	type DatabasePort,
 	type EnsureUserProfileInput,
+	type MeetingParticipantSeed,
 	type MeetingRecord,
 	type ShareRecord,
 	type UserProfile,
@@ -13,6 +14,8 @@ import {
 	validateCreateCallbackInput,
 	validateEnsureUserProfileInput,
 	validateGetMeetingCountAfterDateInput,
+	validateMeetingParticipant,
+	validateMeetingParticipantSeed,
 	validateAppendShareInput,
 	validateCreateMeetingInput,
 	validateMeetingRecord,
@@ -267,15 +270,73 @@ function serializeMeetingPhaseState(
 
 function mapShareRecordRow(row: unknown): ShareRecord {
 	const record = isObject(row) ? row : {};
+	const character = isObject(record.characters) ? record.characters : null;
+	const characterName = character ? asString(character.name) : undefined;
+	const characterIntroStyle = character ? asString(character.intro_style) : undefined;
+	const appCharacterId =
+		characterIntroStyle ??
+		(characterName ? CORE_CHARACTER_ID_BY_NAME.get(characterName) : undefined) ??
+		asNullableString(record.character_id) ??
+		null;
 	return {
 		id: asString(record.id) ?? '',
 		meetingId: asString(record.meeting_id) ?? '',
-		characterId: asNullableString(record.character_id) ?? null,
+		characterId: appCharacterId,
 		isUserShare: asBoolean(record.is_user_share) ?? false,
 		content: asString(record.content) ?? '',
+		interactionType: (asString(record.interaction_type) as ShareRecord['interactionType']) ?? 'standard',
 		significanceScore: asNumber(record.significance_score) ?? Number.NaN,
 		sequenceOrder: asNumber(record.sequence_order) ?? Number.NaN,
 		createdAt: asString(record.created_at) ?? ''
+	};
+}
+
+function cleanTimeLabelFromRow(row: Record<string, unknown>, fallback: string): string {
+	const profileEvolved = isObject(row.profile_evolved) ? row.profile_evolved : null;
+	const cleanTimeLabel =
+		profileEvolved && typeof profileEvolved.cleanTimeLabel === 'string'
+			? profileEvolved.cleanTimeLabel
+			: null;
+	if (isNonEmptyString(cleanTimeLabel)) return cleanTimeLabel;
+	return fallback;
+}
+
+function mapMeetingParticipantRow(row: unknown): MeetingParticipant | null {
+	if (!isObject(row)) return null;
+	const character = isObject(row.characters) ? row.characters : null;
+	if (!character) return null;
+
+	const introStyle = asString(character.intro_style);
+	const coreId = (introStyle && CORE_CHARACTERS.find((entry) => entry.id === introStyle)?.id) ?? null;
+	const coreCharacter =
+		(coreId ? CORE_CHARACTERS.find((entry) => entry.id === coreId) : null) ??
+		CORE_CHARACTERS.find((entry) => entry.name === asString(character.name));
+
+	const fallbackId = asString(character.id) ?? '';
+	const fallbackName = asString(character.name) ?? '';
+	const fallbackTier = (asString(character.tier) as MeetingParticipant['tier']) ?? 'visitor';
+	const fallbackStatus = (asString(character.status) as MeetingParticipant['status']) ?? 'active';
+	const cleanTime = cleanTimeLabelFromRow(character, coreCharacter?.cleanTime ?? '24 hours');
+
+	return {
+		id: introStyle ?? coreCharacter?.id ?? fallbackId,
+		name: coreCharacter?.name ?? fallbackName,
+		tier: coreCharacter?.tier ?? fallbackTier,
+		status: coreCharacter?.status ?? fallbackStatus,
+		archetype: coreCharacter?.archetype ?? (asString(character.archetype) ?? ''),
+		wound: coreCharacter?.wound ?? (asString(character.wound) ?? ''),
+		contradiction: coreCharacter?.contradiction ?? (asString(character.contradiction) ?? ''),
+		voice: coreCharacter?.voice ?? (asString(character.voice) ?? ''),
+		quirk: coreCharacter?.quirk ?? (asString(character.quirk) ?? ''),
+		color: coreCharacter?.color ?? (asString(character.color) ?? ''),
+		avatar: coreCharacter?.avatar ?? (asString(character.avatar) ?? ''),
+		cleanTime,
+		meetingCount: asNumber(character.meeting_count) ?? coreCharacter?.meetingCount ?? 0,
+		lastSeenAt: asNullableString(character.last_seen_at) ?? coreCharacter?.lastSeenAt ?? null,
+		role: (asString(row.role) as MeetingParticipant['role']) ?? 'quiet_presence',
+		isVisitor: (coreCharacter?.tier ?? fallbackTier) === 'visitor',
+		seatOrder: asNumber(row.seat_order) ?? Number.NaN,
+		sharesCount: asNumber(row.shares_count) ?? 0
 	};
 }
 
@@ -309,7 +370,7 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 		const coreNames = CORE_CHARACTERS.map((character) => character.name);
 		const existingResponse = (await supabase
 			.from('characters')
-			.select('id, name')
+			.select('id, name, intro_style')
 			.in('name', coreNames)) as QueryResponseLike<unknown[]>;
 		if (existingResponse.error) return mapUpstreamError(method, existingResponse);
 		if (!Array.isArray(existingResponse.data)) {
@@ -344,13 +405,13 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 						intro_style: character.id
 					}))
 				)
-				.select('id, name')) as QueryResponseLike<unknown[]>;
+				.select('id, name, intro_style')) as QueryResponseLike<unknown[]>;
 			if (insertResponse.error) return mapUpstreamError(method, insertResponse);
 		}
 
 		const finalResponse = (await supabase
 			.from('characters')
-			.select('id, name')
+			.select('id, name, intro_style')
 			.in('name', coreNames)) as QueryResponseLike<unknown[]>;
 		if (finalResponse.error) return mapUpstreamError(method, finalResponse);
 		if (!Array.isArray(finalResponse.data)) {
@@ -366,9 +427,10 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 		for (const row of finalResponse.data) {
 			if (!isObject(row)) continue;
 			const dbId = asString(row.id);
+			const introStyle = asString(row.intro_style);
 			const name = asString(row.name);
-			if (!isNonEmptyString(dbId) || !isNonEmptyString(name)) continue;
-			const domainId = CORE_CHARACTER_ID_BY_NAME.get(name);
+			if (!isNonEmptyString(dbId) || (!isNonEmptyString(introStyle) && !isNonEmptyString(name))) continue;
+			const domainId = introStyle ?? (name ? CORE_CHARACTER_ID_BY_NAME.get(name) : undefined);
 			if (!domainId) continue;
 			dbIdByDomainId.set(domainId, dbId);
 			domainIdByDbId.set(dbId, domainId);
@@ -418,11 +480,114 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 		}
 
 		const coreName = CORE_CHARACTER_NAME_BY_ID.get(characterId);
+		const directLookup = (await supabase
+			.from('characters')
+			.select('id, intro_style')
+			.eq('intro_style', characterId)
+			.maybeSingle()) as QueryResponseLike;
+		if (directLookup.error) return mapUpstreamError(method, directLookup);
+		if (isObject(directLookup.data) && isNonEmptyString(directLookup.data.id)) {
+			return ok(directLookup.data.id);
+		}
+
 		return err(SeamErrorCodes.INPUT_INVALID, `Unknown characterId: ${characterId}`, {
 			method,
 			provider: 'supabase',
 			expectedCoreName: coreName ?? null
 		});
+	}
+
+	async function loadMeetingParticipantsInternal(
+		method: keyof DatabasePort,
+		meetingId: string
+	): Promise<SeamResult<MeetingParticipant[]>> {
+	const response = (await supabase
+		.from('meeting_participants')
+		.select(
+			[
+				'meeting_id',
+				'role',
+				'shares_count',
+				'seat_order',
+				'characters!inner(',
+					'  id,',
+					'  name,',
+					'  tier,',
+					'  archetype,',
+					'  clean_time_start,',
+					'  voice,',
+					'  wound,',
+					'  contradiction,',
+					'  quirk,',
+					'  color,',
+					'  avatar,',
+					'  meeting_count,',
+					'  last_seen_at,',
+					'  status,',
+					'  profile_evolved,',
+					'  intro_style',
+					')'
+				].join(' ')
+			)
+			.eq('meeting_id', meetingId)
+			.order('seat_order', { ascending: true })) as QueryResponseLike<unknown[]>;
+
+		if (response.error) return mapUpstreamError(method, response);
+		if (!Array.isArray(response.data)) {
+			return err(SeamErrorCodes.CONTRACT_VIOLATION, 'meeting participants response is not an array', {
+				method,
+				provider: 'supabase'
+			});
+		}
+
+		const participants = response.data
+			.map((row) => mapMeetingParticipantRow(row))
+			.filter((participant): participant is MeetingParticipant => participant !== null);
+		if (!participants.every((participant) => validateMeetingParticipant(participant))) {
+			return err(SeamErrorCodes.CONTRACT_VIOLATION, 'meeting participants violate MeetingParticipant[]', {
+				method,
+				provider: 'supabase'
+			});
+		}
+		return ok(participants);
+	}
+
+	async function createVisitorCharacter(
+		method: keyof DatabasePort,
+		participant: MeetingParticipantSeed
+	): Promise<SeamResult<string>> {
+		const response = (await supabase
+			.from('characters')
+			.insert({
+				name: participant.name,
+				tier: participant.tier,
+				archetype: participant.archetype,
+				clean_time_start: new Date().toISOString().slice(0, 10),
+				voice: participant.voice,
+				wound: participant.wound,
+				contradiction: participant.contradiction,
+				quirk: participant.quirk,
+				color: participant.color,
+				avatar: participant.avatar,
+				status: participant.status,
+				intro_style: participant.id,
+				profile_evolved: {
+					cleanTimeLabel: participant.cleanTime,
+					sourceParticipantId: participant.id,
+					isVisitor: participant.isVisitor
+				}
+			})
+			.select('id')
+			.single()) as QueryResponseLike;
+		if (response.error) return mapUpstreamError(method, response);
+		const dbId = isObject(response.data) ? asString(response.data.id) : undefined;
+		if (!isNonEmptyString(dbId)) {
+			return err(SeamErrorCodes.CONTRACT_VIOLATION, 'visitor insert did not return a valid id', {
+				method,
+				provider: 'supabase'
+			});
+		}
+		return ok(dbId);
 	}
 
 	return {
@@ -602,6 +767,69 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 			return ok(meeting);
 		},
 
+		async saveMeetingParticipants(input) {
+			if (
+				!isObject(input) ||
+				!isNonEmptyString(input.meetingId) ||
+				!Array.isArray(input.participants) ||
+				!input.participants.every((participant) => validateMeetingParticipantSeed(participant))
+			) {
+				return err(SeamErrorCodes.INPUT_INVALID, 'Invalid saveMeetingParticipants input');
+			}
+
+			const existingParticipants = await loadMeetingParticipantsInternal(
+				'saveMeetingParticipants',
+				input.meetingId
+			);
+			if (!existingParticipants.ok) return existingParticipants;
+			if (existingParticipants.value.length > 0) {
+				return existingParticipants;
+			}
+
+			const participants = [...input.participants].sort((left, right) => left.seatOrder - right.seatOrder);
+			const persistedRows: Array<{
+				meeting_id: string;
+				character_id: string;
+				role: MeetingParticipant['role'];
+				seat_order: number;
+				shares_count: number;
+			}> = [];
+
+			for (const participant of participants) {
+				let dbCharacterId: string;
+				if (participant.isVisitor) {
+					const createdVisitor = await createVisitorCharacter('saveMeetingParticipants', participant);
+					if (!createdVisitor.ok) return createdVisitor;
+					dbCharacterId = createdVisitor.value;
+				} else {
+					const resolved = await resolveDbCharacterId('saveMeetingParticipants', participant.id);
+					if (!resolved.ok) return resolved;
+					dbCharacterId = resolved.value;
+				}
+
+				persistedRows.push({
+					meeting_id: input.meetingId,
+					character_id: dbCharacterId,
+					role: participant.role,
+					seat_order: participant.seatOrder,
+					shares_count: 0
+				});
+			}
+
+			const insertResponse = (await supabase.from('meeting_participants').insert(persistedRows)) as QueryResponseLike;
+			if (insertResponse.error) return mapUpstreamError('saveMeetingParticipants', insertResponse);
+
+			return loadMeetingParticipantsInternal('saveMeetingParticipants', input.meetingId);
+		},
+
+		async getMeetingParticipants(meetingId) {
+			if (!isNonEmptyString(meetingId)) {
+				return err(SeamErrorCodes.INPUT_INVALID, 'Invalid meetingId');
+			}
+
+			return loadMeetingParticipantsInternal('getMeetingParticipants', meetingId);
+		},
+
 		async appendShare(input) {
 			if (!validateAppendShareInput(input)) {
 				return err(SeamErrorCodes.INPUT_INVALID, 'Invalid appendShare input');
@@ -623,14 +851,35 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 					content: input.content,
 					significance_score: input.significanceScore,
 					sequence_order: input.sequenceOrder,
-					interaction_type: 'standard'
+					interaction_type: input.interactionType
 				})
 				.select(
-					'id, meeting_id, character_id, is_user_share, content, significance_score, sequence_order, created_at'
+					'id, meeting_id, character_id, is_user_share, content, interaction_type, significance_score, sequence_order, created_at, characters(id, name, intro_style)'
 				)
 				.single()) as QueryResponseLike;
 
 			if (response.error) return mapUpstreamError('appendShare', response);
+
+			if (dbCharacterId) {
+				const participantRow = (await supabase
+					.from('meeting_participants')
+					.select('shares_count')
+					.eq('meeting_id', input.meetingId)
+					.eq('character_id', dbCharacterId)
+					.maybeSingle()) as QueryResponseLike;
+				if (participantRow.error) return mapUpstreamError('appendShare', participantRow);
+				if (isObject(participantRow.data)) {
+					const nextSharesCount = (asNumber(participantRow.data.shares_count) ?? 0) + 1;
+					const participantUpdate = (await supabase
+						.from('meeting_participants')
+						.update({ shares_count: nextSharesCount })
+						.eq('meeting_id', input.meetingId)
+						.eq('character_id', dbCharacterId)
+						.select('meeting_id')
+						.maybeSingle()) as QueryResponseLike;
+					if (participantUpdate.error) return mapUpstreamError('appendShare', participantUpdate);
+				}
+			}
 
 			const share = mapShareRecordRow(response.data);
 			if (share.characterId !== null) {
@@ -653,7 +902,7 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 			const response = (await supabase
 				.from('shares')
 				.select(
-					'id, meeting_id, character_id, is_user_share, content, significance_score, sequence_order, created_at, meetings!inner(user_id)'
+					'id, meeting_id, character_id, is_user_share, content, interaction_type, significance_score, sequence_order, created_at, characters(id, name, intro_style), meetings!inner(user_id)'
 				)
 				.eq('meetings.user_id', userId)
 				.order('created_at', { ascending: false })
@@ -685,7 +934,7 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 			const response = (await supabase
 				.from('shares')
 				.select(
-					'id, meeting_id, character_id, is_user_share, content, significance_score, sequence_order, created_at'
+					'id, meeting_id, character_id, is_user_share, content, interaction_type, significance_score, sequence_order, created_at, characters(id, name, intro_style)'
 				)
 				.eq('id', shareId)
 				.maybeSingle()) as QueryResponseLike;
@@ -719,7 +968,7 @@ export function createDatabaseAdapter(options: DatabaseAdapterOptions = {}): Dat
 			const response = (await supabase
 				.from('shares')
 				.select(
-					'id, meeting_id, character_id, is_user_share, content, significance_score, sequence_order, created_at'
+					'id, meeting_id, character_id, is_user_share, content, interaction_type, significance_score, sequence_order, created_at, characters(id, name, intro_style)'
 				)
 				.eq('meeting_id', meetingId)
 				.order('sequence_order', { ascending: true })

--- a/app/src/routes/meeting/[id]/+page.server.ts
+++ b/app/src/routes/meeting/[id]/+page.server.ts
@@ -1,5 +1,6 @@
-import { CORE_CHARACTERS } from '$lib/core/characters';
+import { selectCharacters } from '$lib/core/character-selector';
 import { detectCrisisContent, isMeetingInCrisis } from '$lib/core/crisis-engine';
+import { createSeededRandom } from '$lib/core/random-utils';
 import { initializeMeetingPhase } from '$lib/core/ritual-orchestration';
 import { SeamErrorCodes } from '$lib/core/seam';
 import type { MeetingPhaseState } from '$lib/core/types';
@@ -20,6 +21,12 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
 	const crisisFromSetup = detectCrisisContent(initialMind);
 
 	const sharesResult = await locals.seams.database.getMeetingShares(meetingId);
+	if (!sharesResult.ok && sharesResult.error.code === SeamErrorCodes.NOT_FOUND) {
+		throw error(404, 'Meeting not found');
+	}
+	if (!sharesResult.ok) {
+		console.warn(`[meeting page] getMeetingShares failed for meeting=${meetingId}: ${sharesResult.error.message}`);
+	}
 	const crisisFromShares =
 		sharesResult.ok &&
 		isMeetingInCrisis({
@@ -45,6 +52,54 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
 			? persistedPhaseState.value
 			: initializeMeetingPhase();
 
+	const persistedParticipants = await locals.seams.database.getMeetingParticipants(meetingId);
+	if (!persistedParticipants.ok && persistedParticipants.error.code === SeamErrorCodes.NOT_FOUND) {
+		throw error(404, 'Meeting not found');
+	}
+	if (!persistedParticipants.ok) {
+		console.warn(
+			`[meeting page] getMeetingParticipants failed for meeting=${meetingId}: ${persistedParticipants.error.message}`
+		);
+	}
+
+	const participants =
+		persistedParticipants.ok && persistedParticipants.value.length > 0
+			? persistedParticipants.value
+			: (() => {
+					const generated = selectCharacters({
+						random: createSeededRandom(meetingId),
+						nowIso: phaseState.phaseStartedAt.toISOString()
+					}).map((character, seatOrder) => ({ ...character, seatOrder }));
+					return generated;
+				})();
+
+	if (participants.length > 0 && (!persistedParticipants.ok || persistedParticipants.value.length === 0)) {
+		const savedParticipants = await locals.seams.database.saveMeetingParticipants({
+			meetingId,
+			participants
+		});
+		if (savedParticipants.ok && savedParticipants.value.length > 0) {
+			participants.splice(0, participants.length, ...savedParticipants.value);
+		} else if (!savedParticipants.ok) {
+			console.warn(
+				`[meeting page] saveMeetingParticipants failed for meeting=${meetingId}: ${savedParticipants.error.message}`
+			);
+			throw error(502, 'Unable to load meeting roster');
+		} else {
+			throw error(502, 'Unable to load meeting roster');
+		}
+	}
+
+	const transcript = sharesResult.ok
+		? sharesResult.value.map((share) => ({
+				...share,
+				speakerName:
+					share.isUserShare
+						? initialUserName
+						: participants.find((character) => character.id === share.characterId)?.name ?? 'Someone'
+			}))
+		: [];
+
 	return {
 		meetingId,
 		userId: locals.userId,
@@ -56,12 +111,16 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
 		shouldTriggerInitialCrisisSupport,
 		listeningOnly,
 		phaseState,
-		characters: CORE_CHARACTERS.map((character) => ({
+		initialShares: transcript,
+		characters: participants.map((character) => ({
 			id: character.id,
 			name: character.name,
 			avatar: character.avatar,
 			color: character.color,
-			cleanTime: character.cleanTime
+			cleanTime: character.cleanTime,
+			role: character.role,
+			isVisitor: character.isVisitor,
+			seatOrder: character.seatOrder
 		}))
 	};
 };

--- a/app/src/routes/meeting/[id]/+page.svelte
+++ b/app/src/routes/meeting/[id]/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
+	import { onMount } from 'svelte';
+	import { SvelteURLSearchParams } from 'svelte/reactivity';
 	import MeetingCircle from '$lib/components/MeetingCircle.svelte';
 	import MeetingReflection from '$lib/components/MeetingReflection.svelte';
 	import ShareMessage from '$lib/components/ShareMessage.svelte';
 	import SystemMessage from '$lib/components/SystemMessage.svelte';
 	import UserInput from '$lib/components/UserInput.svelte';
+	import { createSeededRandom } from '$lib/core/random-utils';
 	import type { PageData } from './$types';
 
 	interface SeamError {
@@ -20,19 +24,30 @@
 		characterId: string | null;
 		isUserShare: boolean;
 		content: string;
+		interactionType: string;
 		significanceScore: number;
 		sequenceOrder: number;
 		createdAt: string;
 	}
 
-	interface TranscriptEntry extends ShareRecord {
+	interface TranscriptShare extends ShareRecord {
 		speakerName: string;
 	}
 
-	interface CloseSummaryValue {
-		meetingId: string;
-		summary: string;
-		phaseState?: RitualPhaseStateSnapshot;
+	interface TranscriptSystem {
+		id: string;
+		kind: 'system' | 'ritual' | 'action' | 'local-user';
+		text: string;
+	}
+
+	type TranscriptItem = { id: string; kind: 'share'; entry: TranscriptShare } | TranscriptSystem;
+
+	interface RitualPhaseStateSnapshot {
+		currentPhase: string;
+		phaseStartedAt: string | Date | null;
+		roundNumber?: number;
+		charactersSpokenThisRound: string[];
+		userHasSharedInRound: boolean;
 	}
 
 	interface UserShareValue {
@@ -47,6 +62,12 @@
 		expandedText: string;
 	}
 
+	interface CloseSummaryValue {
+		meetingId: string;
+		summary: string;
+		phaseState?: RitualPhaseStateSnapshot;
+	}
+
 	interface CrisisResponseValue {
 		shares: ShareRecord[];
 		phaseState?: RitualPhaseStateSnapshot;
@@ -57,728 +78,1231 @@
 		};
 	}
 
-	interface RitualPhaseStateSnapshot {
-		currentPhase: string;
-		phaseStartedAt: string | Date | null;
-		roundNumber?: number;
-		charactersSpokenThisRound: string[];
-		userHasSharedInRound: boolean;
-	}
-
-	type MeetingPhase = 'sharing' | 'closing' | 'reflection';
+	type InputMode = 'none' | 'intro' | 'topic' | 'share' | 'reflection';
+	type TurnOutcome = 'shared' | 'crisis';
 
 	let { data }: { data: PageData } = $props();
-	const defaultTopic = $derived(data.defaultTopic);
-	const initialUserName = $derived(data.initialUserName);
-	const initialMood = $derived(data.initialMood);
-	const initialCrisisMode = $derived(data.initialCrisisMode === true);
-	const shouldTriggerInitialCrisisSupport = $derived(
-		data.shouldTriggerInitialCrisisSupport === true
+	const meetingId = $derived(data.meetingId);
+	const loadedCharacters = $derived(
+		[...data.characters].sort((left, right) => left.seatOrder - right.seatOrder)
 	);
-	const ROOM_LED_PHASES = new Set([
-		'setup',
-		'opening',
-		'empty_chair',
-		'introductions',
-		'topic_selection'
+	const loadedPhaseState = $derived(
+		(data.phaseState as RitualPhaseStateSnapshot | undefined) ?? null
+	);
+
+	const TOPIC_OPTIONS = [
+		'Staying clean when everything falls apart',
+		"People who don't understand what we've been through",
+		'Trusting yourself again',
+		'The difference between being alone and being lonely',
+		"When the people closest to you don't believe you've changed",
+		'Dealing with the things you did',
+		'Finding reasons to stay',
+		'Coming back after relapse',
+		'The people we lost',
+		'When staying clean feels harder than using'
+	];
+
+	const NEWCOMER_CLEAN_TIME = new Set([
+		'This is my first meeting',
+		'Less than a week',
+		"I'm not clean right now"
 	]);
-	const SHARING_ROUND_PHASES = new Set(['sharing_round_1', 'sharing_round_2', 'sharing_round_3']);
-	let topic = $state('');
-	let userName = $state('');
-	let userMood = $state('present');
-	let userShareText = $state('');
-	let transcript = $state<TranscriptEntry[]>([]);
+
+	const ACTION_LINES: Record<string, string[]> = {
+		marcus: ['Marcus shifts in his chair.', 'Marcus rubs the edge of his coffee cup.'],
+		heather: ['Heather nods once.', 'Heather looks down for a second.'],
+		meechie: ['Meechie leans back and lets it hang.', 'Meechie scrubs a hand over his jaw.'],
+		gemini: ['Gemini exhales through her nose.', 'Gemini folds her arms tighter.'],
+		gypsy: ['Gypsy shifts in her chair.', 'Gypsy taps one finger against her cup.'],
+		chrystal: ['Chrystal looks up over the page.', 'Chrystal smooths the folded paper again.']
+	};
+
+	const sequenceRandom = createSeededRandom(`${meetingId}:room-sequence`);
+	const meetingCharacters = loadedCharacters;
+	const speakingOrder = shuffle(
+		meetingCharacters.filter((character) => character.id !== 'marcus'),
+		createSeededRandom(`${meetingId}:speaking-order`)
+	);
+
+	let transcript = $state<TranscriptItem[]>([]);
 	let expandedShares = $state<Record<string, string>>({});
-	let streamingDraft = $state('');
+	let ritualPhaseState = $state<RitualPhaseStateSnapshot | null>(loadedPhaseState);
+	let topic = $state(data.defaultTopic);
+	let selectedTopic = $state('');
+	let userName = $state(data.initialUserName);
+	let userMood = $state(data.initialMood);
+	let userShareText = $state('');
 	let summaryText = $state('');
-	let statusLine = $state('');
 	let errorMessage = $state('');
-	let crisisMode = $state(false);
-	let crisisResources = $state({
-		title: "If you're in crisis",
-		lines: [
-			'988 - Suicide & Crisis Lifeline',
-			'1-800-662-4357 - SAMHSA National Helpline',
-			'You can stay here with us.'
-		]
-	});
-	let heavyMode = $state(false);
-	let sharing = $state(false);
-	let postingShare = $state(false);
-	let closing = $state(false);
-	let expandingShareId = $state<string | null>(null);
+	let inputMode = $state<InputMode>('none');
+	let currentPrompt = $state('');
+	let crisisMode = $state(data.initialCrisisMode === true);
 	let crisisResponding = $state(false);
-	let setupCrisisSupportRequested = $state(false);
+	let crisisResources = $state<CrisisResponseValue['resources'] | null>(null);
+	let isCharacterThinking = $state(false);
+	let streamingPreview = $state('');
 	let activeCharacterId = $state<string | null>(null);
-	let meetingPhase = $state<MeetingPhase>('sharing');
-	let ritualPhaseState = $state<RitualPhaseStateSnapshot | null>(null);
+	let expandedShareId = $state<string | null>(null);
 	let transcriptContainer: HTMLDivElement | null = null;
+	let initialized = false;
+	let runToken = 0;
+	let localCounter = 0;
+	let currentShareSource: EventSource | null = null;
+	let pendingTurn: {
+		resolve: (value: TurnOutcome) => void;
+		prompt: string;
+	} | null = null;
+
+	const derivedInitialCleanTime = $derived(data.initialCleanTime ?? '');
+	const newcomerGreetingNeeded = $derived(NEWCOMER_CLEAN_TIME.has(derivedInitialCleanTime));
 
 	$effect(() => {
-		if (!topic) topic = defaultTopic;
-		if (!userName) userName = initialUserName;
-		if (userMood === 'present') userMood = initialMood;
-	});
-
-	$effect(() => {
-		const serverPhaseState =
-			(data.phaseState as unknown as RitualPhaseStateSnapshot | undefined) ?? null;
-		if (!ritualPhaseState && serverPhaseState) {
-			ritualPhaseState = serverPhaseState;
-		}
-	});
-
-	$effect(() => {
-		if (!initialCrisisMode) return;
-		if (!crisisMode) crisisMode = true;
-		if (!shouldTriggerInitialCrisisSupport || setupCrisisSupportRequested) return;
-		setupCrisisSupportRequested = true;
-		void requestCrisisSupport(topic || defaultTopic);
-	});
-
-	$effect(() => {
-		const transcriptCount = transcript.length;
+		const transcriptSize = transcript.length;
 		if (transcriptContainer) {
 			transcriptContainer.scrollTop = transcriptContainer.scrollHeight;
 		}
-		void transcriptCount;
+		void transcriptSize;
 	});
 
-	function isRoomLedPhase(phase: string | null | undefined): boolean {
-		return typeof phase === 'string' && ROOM_LED_PHASES.has(phase);
+	function shuffle<T>(items: T[], random: () => number): T[] {
+		const copy = [...items];
+		for (let index = copy.length - 1; index > 0; index -= 1) {
+			const swapIndex = Math.floor(random() * (index + 1));
+			[copy[index], copy[swapIndex]] = [copy[swapIndex], copy[index]];
+		}
+		return copy;
 	}
 
-	function isSharingRoundPhase(phase: string | null | undefined): boolean {
-		return typeof phase === 'string' && SHARING_ROUND_PHASES.has(phase);
+	function nextLocalId(prefix: string): string {
+		localCounter += 1;
+		return `${prefix}-${localCounter}`;
 	}
 
-	function shouldAutoRetryRoomLedShare(phase: string | null | undefined): boolean {
-		return typeof phase === 'string' && ROOM_LED_PHASES.has(phase);
+	function wait(ms: number, token: number): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				if (token !== runToken) {
+					reject(new Error('sequence-cancelled'));
+					return;
+				}
+				resolve();
+			}, ms);
+
+			if (token !== runToken) {
+				clearTimeout(timer);
+				reject(new Error('sequence-cancelled'));
+			}
+		});
 	}
 
-	function shouldDisableUserInput(): boolean {
-		return (
-			postingShare ||
-			sharing ||
-			crisisResponding ||
-			meetingPhase !== 'sharing' ||
-			isRoomLedPhase(ritualPhaseState?.currentPhase)
+	function speakerName(characterId: string | null): string {
+		if (!characterId) return userName;
+		return meetingCharacters.find((character) => character.id === characterId)?.name ?? 'Someone';
+	}
+
+	function shareCount(): number {
+		return transcript.filter((item) => item.kind === 'share' && item.entry.sequenceOrder >= 0)
+			.length;
+	}
+
+	function pushTranscriptItem(item: TranscriptItem) {
+		transcript = [...transcript, item];
+	}
+
+	function pushSystem(text: string) {
+		pushTranscriptItem({ id: nextLocalId('system'), kind: 'system', text });
+	}
+
+	function pushRitual(text: string) {
+		pushTranscriptItem({ id: nextLocalId('ritual'), kind: 'ritual', text });
+	}
+
+	function pushAction(text: string) {
+		pushTranscriptItem({ id: nextLocalId('action'), kind: 'action', text });
+	}
+
+	function pushLocalUserIntro(text: string) {
+		pushTranscriptItem({ id: nextLocalId('user-intro'), kind: 'local-user', text });
+	}
+
+	function upsertShare(share: ShareRecord) {
+		const entry: TranscriptShare = {
+			...share,
+			speakerName: share.isUserShare ? userName : speakerName(share.characterId)
+		};
+		const nextItems = [...transcript];
+		const existingIndex = nextItems.findIndex(
+			(item) => item.kind === 'share' && item.entry.id === share.id
 		);
+		if (existingIndex >= 0) {
+			nextItems[existingIndex] = { id: share.id, kind: 'share', entry };
+		} else {
+			nextItems.push({ id: share.id, kind: 'share', entry });
+		}
+		transcript = nextItems;
+		if (!share.isUserShare && share.characterId) {
+			activeCharacterId = share.characterId;
+		}
 	}
 
-	$effect(() => {
-		const currentRitualPhase = ritualPhaseState?.currentPhase;
-		const userIsTyping = userShareText.trim().length > 0;
-		const shouldAutoRunOpening = isRoomLedPhase(currentRitualPhase);
-		const shouldAutoRunSharingRound = isSharingRoundPhase(currentRitualPhase) && !userIsTyping;
+	function closeCurrentShareSource() {
+		currentShareSource?.close();
+		currentShareSource = null;
+		isCharacterThinking = false;
+		streamingPreview = '';
+	}
 
-		if (
-			meetingPhase !== 'sharing' ||
-			sharing ||
-			postingShare ||
-			closing ||
-			crisisMode ||
-			crisisResponding ||
-			errorMessage ||
-			(!shouldAutoRunOpening && !shouldAutoRunSharingRound)
-		) {
+	function isMeaningfulUserShareText(content: string): boolean {
+		const normalized = content.trim().toLowerCase();
+		return normalized.length > 0 && normalized !== "i'll pass for now." && normalized !== 'ill pass for now.';
+	}
+
+	function meaningfulUserShareCount(): number {
+		return transcript.filter(
+			(item) =>
+				item.kind === 'share' &&
+				item.entry.isUserShare &&
+				isMeaningfulUserShareText(item.entry.content)
+		).length;
+	}
+
+	function latestMeaningfulUserShare(): TranscriptShare | null {
+		for (let index = transcript.length - 1; index >= 0; index -= 1) {
+			const item = transcript[index];
+			if (
+				item.kind === 'share' &&
+				item.entry.isUserShare &&
+				isMeaningfulUserShareText(item.entry.content)
+			) {
+				return item.entry;
+			}
+		}
+		return null;
+	}
+
+	function findCharacterById(characterId: string | undefined) {
+		if (!characterId) return null;
+		return meetingCharacters.find((character) => character.id === characterId) ?? null;
+	}
+
+	function pickFarewellCharacter() {
+		for (let index = transcript.length - 1; index >= 0; index -= 1) {
+			const item = transcript[index];
+			if (item.kind === 'share' && !item.entry.isUserShare && item.entry.characterId) {
+				const matched = findCharacterById(item.entry.characterId);
+				if (matched && matched.id !== 'marcus') return matched;
+			}
+		}
+		return speakingOrder.find((character) => character.id !== 'marcus') ?? meetingCharacters[1] ?? null;
+	}
+
+	function promptForResumedPhase(phase: string | undefined): string {
+		switch (phase) {
+			case 'sharing_round_1':
+				return 'What comes up for you?';
+			case 'sharing_round_2':
+				return 'How does this land?';
+			case 'sharing_round_3':
+				return 'Anything else before we close?';
+			default:
+				return '';
+		}
+	}
+
+	function syncInputModeFromPersistedPhase() {
+		if (!ritualPhaseState) {
+			inputMode = 'none';
+			currentPrompt = '';
 			return;
 		}
 
-		const delay = shouldAutoRunOpening ? (transcript.length === 0 ? 350 : 1200) : 9000;
-		const timer = setTimeout(() => {
-			requestCharacterShare();
-		}, delay);
+		if (crisisMode) {
+			inputMode = 'none';
+			currentPrompt = '';
+			return;
+		}
 
-		return () => clearTimeout(timer);
-	});
+		switch (ritualPhaseState.currentPhase) {
+			case 'topic_selection':
+				inputMode = 'topic';
+				currentPrompt = '';
+				return;
+			case 'introductions':
+				if (ritualPhaseState.charactersSpokenThisRound.length >= meetingCharacters.length) {
+					inputMode = 'intro';
+					currentPrompt = '';
+					return;
+				}
+				break;
+			case 'sharing_round_1':
+				if (!ritualPhaseState.userHasSharedInRound && ritualPhaseState.charactersSpokenThisRound.length >= 2) {
+					inputMode = 'share';
+					currentPrompt = promptForResumedPhase(ritualPhaseState.currentPhase);
+					return;
+				}
+				break;
+			case 'sharing_round_2':
+				if (!ritualPhaseState.userHasSharedInRound && ritualPhaseState.charactersSpokenThisRound.length >= 3) {
+					inputMode = 'share';
+					currentPrompt = promptForResumedPhase(ritualPhaseState.currentPhase);
+					return;
+				}
+				break;
+			case 'sharing_round_3':
+				if (!ritualPhaseState.userHasSharedInRound && ritualPhaseState.charactersSpokenThisRound.length >= 3) {
+					inputMode = 'share';
+					currentPrompt = promptForResumedPhase(ritualPhaseState.currentPhase);
+					return;
+				}
+				break;
+			case 'post_meeting':
+				inputMode = 'reflection';
+				currentPrompt = '';
+				return;
+		}
 
-	function isRecord(value: unknown): value is Record<string, unknown> {
-		return typeof value === 'object' && value !== null;
+		inputMode = 'none';
+		currentPrompt = '';
+	}
+
+	function shouldAutoResumeFromPersistedPhase() {
+		if (!ritualPhaseState || crisisMode) return false;
+		if (ritualPhaseState.userHasSharedInRound) return false;
+		if (ritualPhaseState.charactersSpokenThisRound.length > 0) return false;
+
+		return (
+			ritualPhaseState.currentPhase === 'sharing_round_1' ||
+			ritualPhaseState.currentPhase === 'sharing_round_2' ||
+			ritualPhaseState.currentPhase === 'sharing_round_3' ||
+			ritualPhaseState.currentPhase === 'closing'
+		);
 	}
 
 	function parseSeamResult<T>(value: unknown): SeamResult<T> | null {
-		if (!isRecord(value) || typeof value.ok !== 'boolean') return null;
-		if (value.ok) return { ok: true, value: value.value as T };
 		if (
-			!isRecord(value.error) ||
-			typeof value.error.message !== 'string' ||
-			typeof value.error.code !== 'string'
+			!value ||
+			typeof value !== 'object' ||
+			typeof (value as { ok?: unknown }).ok !== 'boolean'
+		) {
+			return null;
+		}
+		const result = value as {
+			ok: boolean;
+			value?: T;
+			error?: { code?: unknown; message?: unknown; details?: unknown };
+		};
+		if (result.ok) return { ok: true, value: result.value as T };
+		if (
+			!result.error ||
+			typeof result.error.code !== 'string' ||
+			typeof result.error.message !== 'string'
 		) {
 			return null;
 		}
 		return {
 			ok: false,
 			error: {
-				code: value.error.code,
-				message: value.error.message,
-				details: isRecord(value.error.details) ? value.error.details : undefined
+				code: result.error.code,
+				message: result.error.message,
+				details:
+					result.error.details && typeof result.error.details === 'object'
+						? (result.error.details as Record<string, unknown>)
+						: undefined
 			}
 		};
 	}
 
-	function characterName(characterId: string | null): string {
-		if (!characterId) return userName;
-		const character = data.characters.find((entry) => entry.id === characterId);
-		return character?.name ?? 'Character';
+	function maybeAddNonverbalReaction(excludedIds: string[]) {
+		if (sequenceRandom() > 0.3) return;
+		const candidate = speakingOrder.find((character) => !excludedIds.includes(character.id));
+		if (!candidate) return;
+		const actions = ACTION_LINES[candidate.id] ?? [`${candidate.name} shifts in their chair.`];
+		const line = actions[Math.floor(sequenceRandom() * actions.length)] ?? actions[0];
+		pushAction(line);
 	}
 
-	function upsertShare(share: ShareRecord) {
-		const speakerName = share.isUserShare ? userName : characterName(share.characterId);
-		const entry: TranscriptEntry = { ...share, speakerName };
-		const existingIndex = transcript.findIndex((item) => item.id === share.id);
-
-		if (existingIndex >= 0) {
-			const copy = [...transcript];
-			copy[existingIndex] = entry;
-			transcript = copy.sort((left, right) => left.sequenceOrder - right.sequenceOrder);
-		} else {
-			transcript = [...transcript, entry].sort(
-				(left, right) => left.sequenceOrder - right.sequenceOrder
-			);
-		}
-
-		if (!entry.isUserShare && entry.characterId) activeCharacterId = entry.characterId;
+	function maybeAddAlmostShare(excludedIds: string[]) {
+		if (sequenceRandom() > 0.2) return;
+		const candidate = speakingOrder.find((character) => !excludedIds.includes(character.id));
+		if (!candidate) return;
+		pushAction(`${candidate.name} starts to say something, stops.`);
 	}
 
-	async function submitUserShare(content: string = userShareText.trim()) {
-		if (!content || postingShare || data.listeningOnly) return;
-
+	async function streamCharacterShare(
+		options: {
+			characterId?: string;
+			interactionType?: string;
+		} = {}
+	): Promise<ShareRecord> {
 		errorMessage = '';
-		statusLine = '';
-		postingShare = true;
+		closeCurrentShareSource();
 
-		try {
-			const response = await fetch(`/meeting/${data.meetingId}/user-share`, {
-				method: 'POST',
-				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify({
-					content,
-					sequenceOrder: transcript.length,
-					interactionType: 'standard',
-					isFirstUserShare: transcript.every((entry) => !entry.isUserShare)
-				})
-			});
-			const payload = parseSeamResult<UserShareValue>(await response.json());
-
-			if (!payload) {
-				errorMessage = 'Unexpected user-share response format.';
-				return;
-			}
-			if (!payload.ok) {
-				errorMessage = payload.error.message;
-				return;
-			}
-
-			upsertShare(payload.value.share);
-			crisisMode = payload.value.crisis;
-			heavyMode = payload.value.heavy;
-			if (payload.value.phaseState) ritualPhaseState = payload.value.phaseState;
-			userShareText = '';
-			statusLine = crisisMode
-				? 'Crisis mode detected. The room will stay with you.'
-				: heavyMode
-					? 'Your share was saved (heavy topic noted).'
-					: 'Your share was saved.';
-
-			if (crisisMode) {
-				await requestCrisisSupport(content);
-			}
-		} catch (cause) {
-			errorMessage = cause instanceof Error ? cause.message : String(cause);
-		} finally {
-			postingShare = false;
-		}
-	}
-
-	async function submitPass() {
-		if (data.listeningOnly) return;
-		await submitUserShare("I'll pass for now.");
-	}
-
-	async function requestExpandShare(shareId: string) {
-		const selected = transcript.find((entry) => entry.id === shareId);
-		if (!selected || selected.isUserShare || expandingShareId) return;
-
-		errorMessage = '';
-		statusLine = '';
-		expandingShareId = shareId;
-
-		try {
-			const response = await fetch(`/meeting/${data.meetingId}/expand`, {
-				method: 'POST',
-				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify({
-					shareId,
-					topic,
-					recentShares: transcript.slice(-6).map((entry) => ({
-						speaker: entry.speakerName,
-						content: entry.content
-					}))
-				})
-			});
-			const payload = parseSeamResult<ExpandShareValue>(await response.json());
-
-			if (!payload) {
-				errorMessage = 'Unexpected expand response format.';
-				return;
-			}
-			if (!payload.ok) {
-				errorMessage = payload.error.message;
-				return;
-			}
-
-			expandedShares = {
-				...expandedShares,
-				[payload.value.shareId]: payload.value.expandedText
-			};
-			statusLine = 'Expanded share ready.';
-		} catch (cause) {
-			errorMessage = cause instanceof Error ? cause.message : String(cause);
-		} finally {
-			expandingShareId = null;
-		}
-	}
-
-	function requestCharacterShare() {
-		if (sharing || crisisMode || meetingPhase !== 'sharing') return;
-
-		errorMessage = '';
-		statusLine = '';
-		streamingDraft = '';
-		sharing = true;
-
-		const search = new URLSearchParams({
+		const search = new SvelteURLSearchParams({
 			topic,
-			sequenceOrder: String(transcript.length),
+			sequenceOrder: String(shareCount()),
 			crisisMode: crisisMode ? '1' : '0',
-			interactionType: 'respond_to',
+			interactionType: options.interactionType ?? 'standard',
 			userName,
 			userMood
 		});
+		if (options.characterId) search.set('characterId', options.characterId);
 
-		const eventSource = new EventSource(`/meeting/${data.meetingId}/share?${search.toString()}`);
+		return await new Promise<ShareRecord>((resolve, reject) => {
+			const source = new EventSource(`/meeting/${meetingId}/share?${search.toString()}`);
+			currentShareSource = source;
+			isCharacterThinking = true;
+			let resolved = false;
 
-		eventSource.addEventListener('chunk', (event) => {
-			const parsed = parseSeamResult<{ chunk?: string }>(
-				JSON.parse((event as MessageEvent<string>).data)
-			);
-			if (parsed?.ok && typeof parsed.value.chunk === 'string') {
-				streamingDraft = streamingDraft
-					? `${streamingDraft} ${parsed.value.chunk}`
-					: parsed.value.chunk;
-			}
-		});
+			source.addEventListener('meta', (event) => {
+				const parsed = parseSeamResult<{ character?: { id?: string } }>(
+					JSON.parse((event as MessageEvent<string>).data)
+				);
+				if (parsed?.ok && parsed.value.character?.id) {
+					activeCharacterId = parsed.value.character.id;
+				}
+			});
 
-		eventSource.addEventListener('persisted', (event) => {
-			const parsed = parseSeamResult<{
-				share?: ShareRecord;
-				phaseState?: RitualPhaseStateSnapshot;
-				generation?: { attempts?: number; fallbackUsed?: boolean };
-			}>(JSON.parse((event as MessageEvent<string>).data));
-			if (parsed?.ok) {
+			source.addEventListener('chunk', (event) => {
+				const parsed = parseSeamResult<{ chunk?: string }>(
+					JSON.parse((event as MessageEvent<string>).data)
+				);
+				if (parsed?.ok && typeof parsed.value.chunk === 'string') {
+					streamingPreview = `${streamingPreview}${streamingPreview ? ' ' : ''}${parsed.value.chunk}`;
+				}
+			});
+
+			source.addEventListener('persisted', (event) => {
+				const parsed = parseSeamResult<{
+					share?: ShareRecord;
+					phaseState?: RitualPhaseStateSnapshot;
+				}>(JSON.parse((event as MessageEvent<string>).data));
+				if (!parsed?.ok || !parsed.value.share) return;
 				if (parsed.value.phaseState) ritualPhaseState = parsed.value.phaseState;
-			}
-			if (parsed?.ok && isRecord(parsed.value.share)) {
-				upsertShare(parsed.value.share as ShareRecord);
-				statusLine = parsed.value.generation?.fallbackUsed
-					? 'Character share saved (safe fallback used).'
-					: 'Character share generated and saved.';
-				streamingDraft = '';
-			}
-		});
+				upsertShare(parsed.value.share);
+				closeCurrentShareSource();
+				resolved = true;
+				resolve(parsed.value.share);
+			});
 
-		eventSource.addEventListener('error', (event) => {
-			let parsed: SeamResult<unknown> | null = null;
-			try {
-				parsed = parseSeamResult(JSON.parse((event as MessageEvent<string>).data));
-			} catch {
-				parsed = null;
-			}
-			const parsedMessage = parsed && !parsed.ok ? parsed.error.message : 'Share stream failed.';
-			const shouldRetryRoomLedShare = shouldAutoRetryRoomLedShare(ritualPhaseState?.currentPhase);
-			if (parsedMessage.toLowerCase().includes('crisis mode')) {
-				crisisMode = true;
-				errorMessage = '';
-				statusLine = 'Crisis mode is active. Character shares are paused.';
-			} else if (shouldRetryRoomLedShare) {
-				errorMessage = '';
-				statusLine = 'Character share failed. Retrying the room.';
-			} else {
-				errorMessage = parsedMessage;
-			}
-			eventSource.close();
-			sharing = false;
-		});
+			source.addEventListener('error', (event) => {
+				let parsed: SeamResult<unknown> | null = null;
+				try {
+					parsed = parseSeamResult(JSON.parse((event as MessageEvent<string>).data));
+				} catch {
+					parsed = null;
+				}
+				closeCurrentShareSource();
+				if (resolved) return;
+				reject(new Error(parsed && !parsed.ok ? parsed.error.message : 'Share stream failed.'));
+			});
 
-		eventSource.addEventListener('done', () => {
-			eventSource.close();
-			sharing = false;
+			source.addEventListener('done', () => {
+				closeCurrentShareSource();
+			});
 		});
+	}
+
+	async function postUserShare(content: string): Promise<UserShareValue> {
+		const response = await fetch(`/meeting/${meetingId}/user-share`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				content,
+				sequenceOrder: shareCount(),
+				interactionType: 'standard',
+				isFirstUserShare: transcript.every(
+					(item) => item.kind !== 'share' || item.entry.isUserShare === false
+				)
+			})
+		});
+		const payload = parseSeamResult<UserShareValue>(await response.json());
+		if (!payload) throw new Error('Unexpected user-share response.');
+		if (!payload.ok) throw new Error(payload.error.message);
+		upsertShare(payload.value.share);
+		if (payload.value.phaseState) ritualPhaseState = payload.value.phaseState;
+		crisisMode = payload.value.crisis;
+		return payload.value;
 	}
 
 	async function requestCrisisSupport(userText: string) {
 		if (crisisResponding) return;
-
-		errorMessage = '';
 		crisisResponding = true;
-		statusLine = '... room goes quiet ...';
-
 		try {
-			const response = await fetch(`/meeting/${data.meetingId}/crisis`, {
+			const response = await fetch(`/meeting/${meetingId}/crisis`, {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify({
 					userText,
 					userName,
-					sequenceOrder: transcript.length
+					sequenceOrder: shareCount()
 				})
 			});
 			const payload = parseSeamResult<CrisisResponseValue>(await response.json());
-
-			if (!payload) {
-				errorMessage = 'Unexpected crisis response format.';
-				return;
-			}
-			if (!payload.ok) {
-				errorMessage = payload.error.message;
-				return;
-			}
-
-			for (const share of payload.value.shares) {
-				upsertShare(share);
-			}
+			if (!payload) throw new Error('Unexpected crisis response.');
+			if (!payload.ok) throw new Error(payload.error.message);
+			for (const share of payload.value.shares) upsertShare(share);
 			if (payload.value.phaseState) ritualPhaseState = payload.value.phaseState;
-			if (payload.value.resources?.sticky) {
-				crisisResources = {
-					title: payload.value.resources.title,
-					lines: payload.value.resources.lines
-				};
-			}
-			statusLine = 'Crisis support responses added. You are not alone.';
-		} catch (cause) {
-			errorMessage = cause instanceof Error ? cause.message : String(cause);
+			crisisResources = payload.value.resources;
+			crisisMode = true;
+			inputMode = 'none';
+			currentPrompt = '';
+			pushSystem('The room stopped and turned toward you.');
 		} finally {
 			crisisResponding = false;
 		}
 	}
 
-	async function requestCloseSummary() {
-		if (closing || meetingPhase !== 'sharing') return;
-
-		errorMessage = '';
-		statusLine = '';
-		closing = true;
-		meetingPhase = 'closing';
-
+	async function requestExpandShare(shareId: string) {
+		const selected = transcript.find((item) => item.kind === 'share' && item.entry.id === shareId);
+		if (!selected || selected.kind !== 'share' || selected.entry.isUserShare || expandedShareId)
+			return;
+		expandedShareId = shareId;
 		try {
-			const response = await fetch(`/meeting/${data.meetingId}/close`, {
+			const response = await fetch(`/meeting/${meetingId}/expand`, {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify({
+					shareId,
 					topic,
-					lastShares: transcript.slice(-8).map((entry) => ({
-						speakerName: entry.speakerName,
-						content: entry.content
-					}))
+					recentShares: transcript
+						.filter(
+							(item): item is { id: string; kind: 'share'; entry: TranscriptShare } =>
+								item.kind === 'share'
+						)
+						.slice(-6)
+						.map((item) => ({
+							speaker: item.entry.speakerName,
+							content: item.entry.content
+						}))
 				})
 			});
-			const payload = parseSeamResult<CloseSummaryValue>(await response.json());
-
-			if (!payload) {
-				errorMessage = 'Unexpected close response format.';
-				meetingPhase = 'sharing';
-				return;
-			}
-			if (!payload.ok) {
-				errorMessage = payload.error.message;
-				meetingPhase = 'sharing';
-				return;
-			}
-
-			summaryText = payload.value.summary;
-			if (payload.value.phaseState) ritualPhaseState = payload.value.phaseState;
-			meetingPhase = 'reflection';
-			statusLine = 'Close summary ready.';
+			const payload = parseSeamResult<ExpandShareValue>(await response.json());
+			if (!payload) throw new Error('Unexpected expand response.');
+			if (!payload.ok) throw new Error(payload.error.message);
+			expandedShares = { ...expandedShares, [payload.value.shareId]: payload.value.expandedText };
 		} catch (cause) {
 			errorMessage = cause instanceof Error ? cause.message : String(cause);
-			meetingPhase = 'sharing';
 		} finally {
-			closing = false;
+			expandedShareId = null;
 		}
 	}
+
+	function introText(): string {
+		const cleanTimeLine = derivedInitialCleanTime ? ` ${derivedInitialCleanTime}.` : '';
+		return `I'm ${userName}. I'm an addict.${cleanTimeLine}`;
+	}
+
+	function hasAskedHardQuestion(): boolean {
+		return transcript.some(
+			(item) =>
+				item.kind === 'share' &&
+				!item.entry.isUserShare &&
+				item.entry.interactionType === 'hard_question'
+		);
+	}
+
+	function shouldAskHardQuestion(): boolean {
+		return !data.listeningOnly && meaningfulUserShareCount() >= 2 && !hasAskedHardQuestion();
+	}
+
+	function lastUserTurnWasMeaningful(): boolean {
+		for (let index = transcript.length - 1; index >= 0; index -= 1) {
+			const item = transcript[index];
+			if (item.kind === 'share') {
+				return item.entry.isUserShare && isMeaningfulUserShareText(item.entry.content);
+			}
+		}
+		return false;
+	}
+
+	function resolveRoundTwoSpeakers() {
+		let first = speakingOrder[2] ?? speakingOrder[0] ?? meetingCharacters[0];
+		let second = speakingOrder[3] ?? speakingOrder[1] ?? speakingOrder[0] ?? meetingCharacters[1] ?? first;
+		const latestUserShare = latestMeaningfulUserShare();
+		const parallelCharacterId = latestUserShare
+			? detectParallelStoryCharacter(latestUserShare.content)
+			: null;
+
+		if (parallelCharacterId && parallelCharacterId !== second.id) {
+			const mapped = findCharacterById(parallelCharacterId);
+			if (mapped) {
+				first = mapped;
+			}
+		}
+
+		if (second.id === first.id) {
+			second =
+				speakingOrder.find(
+					(character) => character.id !== first.id && character.id !== (speakingOrder[2]?.id ?? '')
+				) ??
+				meetingCharacters.find((character) => character.id !== first.id) ??
+				second;
+		}
+
+		return { first, second };
+	}
+
+	async function waitForUserTurn(prompt: string): Promise<TurnOutcome> {
+		currentPrompt = prompt;
+		if (data.listeningOnly) {
+			inputMode = 'none';
+			currentPrompt = '';
+			pendingTurn = { resolve: () => undefined, prompt };
+			await wait(1200, runToken);
+			return await handleSubmitShare("I'll pass for now.");
+		}
+		inputMode = 'share';
+		return await new Promise<TurnOutcome>((resolve) => {
+			pendingTurn = { resolve, prompt };
+		});
+	}
+
+	async function continueFromPersistedPhase(currentPhase: string | undefined) {
+		if (!currentPhase || crisisMode) return;
+		switch (currentPhase) {
+			case 'sharing_round_1':
+				await runRoundOne();
+				return;
+			case 'sharing_round_2':
+				await runRoundTwo();
+				return;
+			case 'sharing_round_3':
+				if (shouldAskHardQuestion()) {
+					await wait(900, runToken);
+					await streamCharacterShare({
+						characterId: sequenceRandom() > 0.5 ? 'meechie' : 'marcus',
+						interactionType: 'hard_question'
+					});
+					await wait(1200, runToken);
+				}
+				await runRoundThree();
+				return;
+			case 'closing':
+				await runClosing();
+				return;
+		}
+	}
+
+	async function handleSubmitShare(content = userShareText.trim()): Promise<TurnOutcome> {
+		if (!content || crisisResponding) return 'shared';
+		try {
+			inputMode = 'none';
+			currentPrompt = '';
+			const result = await postUserShare(content);
+			userShareText = '';
+			if (result.heavy) {
+				pushAction('The room goes quiet.');
+				await wait(3500, runToken);
+			} else {
+				await wait(1500, runToken);
+			}
+			if (result.crisis) {
+				await requestCrisisSupport(content);
+				pendingTurn?.resolve('crisis');
+				pendingTurn = null;
+				return 'crisis';
+			}
+			const waitingTurn = pendingTurn;
+			pendingTurn = null;
+			waitingTurn?.resolve('shared');
+			if (!waitingTurn) {
+				await continueFromPersistedPhase(result.phaseState?.currentPhase);
+			}
+			pendingTurn = null;
+			return 'shared';
+		} catch (cause) {
+			errorMessage = cause instanceof Error ? cause.message : String(cause);
+			inputMode = 'share';
+			return 'shared';
+		}
+	}
+
+	async function handlePass() {
+		await handleSubmitShare("I'll pass for now.");
+	}
+
+	async function handleIntroduceSelf() {
+		inputMode = 'none';
+		pushLocalUserIntro(introText());
+		pushSystem(`Hi ${userName}.`);
+		if (newcomerGreetingNeeded) {
+			pushAction('A couple people nod like they knew this might be your first time.');
+			await wait(1200, runToken);
+		} else {
+			await wait(1200, runToken);
+		}
+		await streamCharacterShare({ characterId: 'marcus', interactionType: 'standard' });
+		selectedTopic = TOPIC_OPTIONS.includes(topic) ? topic : '';
+		inputMode = 'topic';
+	}
+
+	async function chooseTopic(nextTopic: string) {
+		topic = nextTopic;
+		selectedTopic = nextTopic;
+		inputMode = 'none';
+		await streamCharacterShare({ characterId: 'marcus', interactionType: 'respond_to' });
+		await wait(900, runToken);
+		await runRounds();
+	}
+
+	async function runRounds() {
+		await runRoundOne();
+	}
+
+	async function runRoundOne() {
+		const roundOneA = speakingOrder[0] ?? meetingCharacters[0];
+		const roundOneB = speakingOrder[1] ?? meetingCharacters[1] ?? roundOneA;
+		await streamCharacterShare({ characterId: roundOneA?.id, interactionType: 'respond_to' });
+		if (roundOneB && sequenceRandom() > 0.6) {
+			await wait(700, runToken);
+			await streamCharacterShare({
+				characterId: roundOneB.id,
+				interactionType: 'crosstalk'
+			});
+		}
+		maybeAddNonverbalReaction([roundOneA?.id ?? '', roundOneB?.id ?? '']);
+		await wait(900, runToken);
+		await streamCharacterShare({ characterId: roundOneB?.id, interactionType: 'respond_to' });
+		await wait(900, runToken);
+		const outcome = await waitForUserTurn('What comes up for you?');
+		if (outcome === 'crisis') return;
+		await runRoundTwo();
+	}
+
+	async function runRoundTwo() {
+		const { first, second } = resolveRoundTwoSpeakers();
+		await streamCharacterShare({ characterId: first?.id, interactionType: 'respond_to' });
+		maybeAddAlmostShare([first?.id ?? '', second?.id ?? '']);
+		await wait(900, runToken);
+		if (second && sequenceRandom() > 0.6) {
+			await streamCharacterShare({ characterId: second.id, interactionType: 'crosstalk' });
+			await wait(700, runToken);
+		}
+		await streamCharacterShare({ characterId: second?.id, interactionType: 'respond_to' });
+		const questionPool = [speakingOrder[0], speakingOrder[1], first, second].filter(
+			(character, index, list): character is NonNullable<typeof character> =>
+				Boolean(character) && list.findIndex((candidate) => candidate?.id === character?.id) === index
+		);
+		const questionAsker = questionPool[Math.floor(sequenceRandom() * questionPool.length)];
+		if (questionAsker) {
+			await wait(900, runToken);
+			await streamCharacterShare({ characterId: questionAsker.id, interactionType: 'respond_to' });
+		}
+		const outcome = await waitForUserTurn('How does this land?');
+		if (outcome === 'crisis') return;
+
+		if (shouldAskHardQuestion()) {
+			await wait(900, runToken);
+			await streamCharacterShare({
+				characterId: sequenceRandom() > 0.5 ? 'meechie' : 'marcus',
+				interactionType: 'hard_question'
+			});
+			await wait(1200, runToken);
+		}
+		await runRoundThree();
+	}
+
+	async function runRoundThree() {
+		const roundThreeA = speakingOrder[4] ?? speakingOrder[2] ?? meetingCharacters[2] ?? meetingCharacters[0];
+		const roundThreeB =
+			speakingOrder[5] ?? speakingOrder[3] ?? meetingCharacters[3] ?? meetingCharacters[1] ?? roundThreeA;
+		await streamCharacterShare({ characterId: roundThreeA?.id, interactionType: 'respond_to' });
+		maybeAddNonverbalReaction([roundThreeA?.id ?? '', roundThreeB?.id ?? '']);
+		await wait(900, runToken);
+		await streamCharacterShare({ characterId: roundThreeB?.id, interactionType: 'respond_to' });
+		await wait(900, runToken);
+		await streamCharacterShare({ characterId: 'marcus', interactionType: 'respond_to' });
+		const outcome = await waitForUserTurn('Anything else before we close?');
+		if (outcome === 'crisis') return;
+		await runClosing();
+	}
+
+	function detectParallelStoryCharacter(content: string): string | null {
+		const normalized = content.toLowerCase();
+		if (normalized.includes('custody') || normalized.includes('kid')) return 'marcus';
+		if (normalized.includes('prison') || normalized.includes('jail')) return 'heather';
+		if (normalized.includes('relapse') || normalized.includes('slip')) return 'gemini';
+		if (
+			normalized.includes('running') ||
+			normalized.includes('moved') ||
+			normalized.includes('city')
+		)
+			return 'gypsy';
+		return null;
+	}
+
+	async function runClosing() {
+		if (lastUserTurnWasMeaningful()) {
+			await streamCharacterShare({ characterId: 'marcus', interactionType: 'respond_to' });
+			await wait(1100, runToken);
+		}
+		await streamCharacterShare({ characterId: 'marcus', interactionType: 'respond_to' });
+		await wait(2000, runToken);
+		const goodbyeCharacter = findCharacterById('heather') ?? speakingOrder[0] ?? meetingCharacters[1] ?? null;
+		if (goodbyeCharacter) {
+			await streamCharacterShare({
+				characterId: goodbyeCharacter.id,
+				interactionType: 'respond_to'
+			});
+			await wait(1500, runToken);
+		}
+		pushRitual('— Keep coming back —');
+		await wait(900, runToken);
+		const farewellCharacter = pickFarewellCharacter();
+		if (farewellCharacter) {
+			await streamCharacterShare({
+				characterId: farewellCharacter.id,
+				interactionType: 'farewell'
+			});
+		}
+
+		const response = await fetch(`/meeting/${meetingId}/close`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				topic,
+				lastShares: transcript
+					.filter(
+						(item): item is { id: string; kind: 'share'; entry: TranscriptShare } =>
+							item.kind === 'share'
+					)
+					.slice(-8)
+					.map((item) => ({
+						speakerName: item.entry.speakerName,
+						content: item.entry.content
+					}))
+			})
+		});
+		const payload = parseSeamResult<CloseSummaryValue>(await response.json());
+		if (!payload) throw new Error('Unexpected close response.');
+		if (!payload.ok) throw new Error(payload.error.message);
+		summaryText = payload.value.summary;
+		if (payload.value.phaseState) ritualPhaseState = payload.value.phaseState;
+		currentPrompt = '';
+		inputMode = 'reflection';
+	}
+
+	async function runFreshMeeting(token: number) {
+		try {
+			await wait(500, token);
+			pushSystem("This chair stays empty for everyone who couldn't make it tonight.");
+			await wait(2000, token);
+			await streamCharacterShare({ characterId: 'marcus' });
+			await wait(3000, token);
+			pushSystem('— moment of silence —');
+			await wait(3000, token);
+			pushAction('Chrystal pulls out a folded paper.');
+			await wait(800, token);
+			await streamCharacterShare({ characterId: 'chrystal' });
+			await wait(3500, token);
+			pushSystem('— introductions —');
+			await wait(800, token);
+
+			for (const character of meetingCharacters) {
+				await streamCharacterShare({ characterId: character.id });
+				if (sequenceRandom() > 0.5) {
+					pushSystem(`Hi ${character.name}!`);
+				}
+				await wait(600, token);
+			}
+
+			pushAction('The room settles. Everyone is waiting.');
+			await wait(1500, token);
+			inputMode = 'intro';
+		} catch (cause) {
+			if (cause instanceof Error && cause.message === 'sequence-cancelled') return;
+			errorMessage = cause instanceof Error ? cause.message : String(cause);
+		}
+	}
+
+	onMount(() => {
+		if (initialized) return;
+		initialized = true;
+		runToken += 1;
+		const token = runToken;
+
+		for (const share of data.initialShares ?? []) {
+			upsertShare(share as ShareRecord);
+		}
+
+		if (
+			data.initialCrisisMode &&
+			data.shouldTriggerInitialCrisisSupport &&
+			!data.initialShares?.length
+		) {
+			void requestCrisisSupport(topic);
+			return () => {
+				runToken += 1;
+			};
+		}
+
+		if (!data.initialShares?.length) {
+			void runFreshMeeting(token);
+		} else if (shouldAutoResumeFromPersistedPhase()) {
+			void continueFromPersistedPhase(ritualPhaseState?.currentPhase);
+		} else {
+			syncInputModeFromPersistedPhase();
+		}
+
+		return () => {
+			closeCurrentShareSource();
+			runToken += 1;
+		};
+	});
 </script>
 
-<main class="room-shell">
-	<section class="room-panel room-meta">
-		<header class="room-head">
-			<p class="kicker">Room Live</p>
-			<h1>Meeting Room</h1>
-			<p class="meeting-id">Meeting ID: <code>{data.meetingId}</code></p>
-			<p class="phase-pill">Phase: {ritualPhaseState?.currentPhase ?? 'unknown'}</p>
-			<p class="member-line">{userName} · {data.initialCleanTime ?? 'clean time not set'}</p>
-		</header>
-
-		<MeetingCircle characters={data.characters} {activeCharacterId} {crisisMode} />
-
-		<section class="edit-grid" aria-label="Meeting metadata">
-			<label>
-				<span>Topic</span>
-				<input bind:value={topic} />
-			</label>
-			<label>
-				<span>Your Name</span>
-				<input bind:value={userName} />
-			</label>
-			<label>
-				<span>Mood</span>
-				<input bind:value={userMood} />
-			</label>
-		</section>
+<main class="meeting-shell">
+	<section class="circle-wrap">
+		<MeetingCircle characters={meetingCharacters} {activeCharacterId} {crisisMode} />
 	</section>
 
-	<section class="room-panel room-transcript">
-		<div class="toolbar">
-			{#if sharing}
-				<p class="toolbar-status">The room keeps moving on its own.</p>
-			{/if}
-			<button
-				type="button"
-				onclick={requestCloseSummary}
-				disabled={closing || sharing || meetingPhase !== 'sharing'}
-			>
-				{closing ? 'Closing Meeting...' : 'Close Meeting'}
-			</button>
-		</div>
-
+	<section class="transcript-wrap">
 		{#if errorMessage}
-			<SystemMessage message={errorMessage} kind="error" />
+			<div class="inline-system"><SystemMessage message={errorMessage} kind="error" /></div>
 		{/if}
-		{#if statusLine}
-			<SystemMessage message={statusLine} kind="info" />
-		{/if}
-		{#if streamingDraft}
-			<SystemMessage message={`Streaming: ${streamingDraft}`} kind="success" />
+		{#if isCharacterThinking}
+			<div class="thinking-line" aria-live="polite" aria-label="Someone is gathering themselves to speak">
+				<span></span><span></span><span></span>
+			</div>
 		{/if}
 
-		<div bind:this={transcriptContainer} class="transcript-scroll" aria-live="polite">
-			{#if transcript.length === 0}
-				<SystemMessage message="No shares yet." kind="info" />
-			{:else}
-				<ol class="transcript-list">
-					{#each transcript as entry (entry.id)}
+		<div bind:this={transcriptContainer} class="transcript-scroll">
+			<ol class="transcript-list">
+				{#if streamingPreview}
+					<li class="streaming-preview">
+						<p class="speaker">{speakerName(activeCharacterId)}</p>
+						<p>{streamingPreview}</p>
+					</li>
+				{/if}
+				{#each transcript as item (item.id)}
+					{#if item.kind === 'share'}
 						<ShareMessage
-							{entry}
-							expandedText={expandedShares[entry.id]}
+							entry={item.entry}
+							expandedText={expandedShares[item.entry.id]}
 							onExpand={requestExpandShare}
-							expanding={expandingShareId === entry.id}
+							expanding={expandedShareId === item.entry.id}
 						/>
-					{/each}
-				</ol>
-			{/if}
+					{:else if item.kind === 'local-user'}
+						<li class="local-user-share">
+							<p class="speaker">{userName}</p>
+							<p>{item.text}</p>
+						</li>
+					{:else if item.kind === 'action'}
+						<li class="action-line"><p>{item.text}</p></li>
+					{:else}
+						<li class="inline-system">
+							<SystemMessage message={item.text} kind={item.kind === 'ritual' ? 'ritual' : 'info'} />
+						</li>
+					{/if}
+				{/each}
+			</ol>
 		</div>
 	</section>
 
-	<section class="room-panel room-turn">
+	<section class="input-wrap">
 		{#if crisisMode}
-			<section class="crisis-card" role="status" aria-live="polite">
-				<h2>{crisisResources.title}</h2>
-				{#each crisisResources.lines as line (`${line}`)}
-					<p>{line}</p>
-				{/each}
-			</section>
+			<div class="inline-system">
+				<SystemMessage message="The meeting stopped. Stay with the room." kind="error" />
+			</div>
+			{#if crisisResources}
+				<div class="control-card crisis-card">
+					<p class="prompt-line">{crisisResources.title}</p>
+					<ul class="resource-list">
+						{#each crisisResources.lines as line (line)}
+							<li>{line}</li>
+						{/each}
+					</ul>
+				</div>
+			{/if}
 		{/if}
 
-		{#if meetingPhase === 'reflection' && summaryText}
-			<MeetingReflection summary={summaryText} onClose={() => (meetingPhase = 'sharing')} />
+		{#if inputMode === 'intro'}
+			<div class="control-card">
+				<button class="primary-btn" type="button" onclick={handleIntroduceSelf}>
+					Introduce yourself
+				</button>
+			</div>
+		{:else if inputMode === 'topic'}
+			<div class="control-card">
+				<p class="prompt-line">Pick what is on the table tonight.</p>
+				<div class="topic-grid">
+					{#each TOPIC_OPTIONS as option (option)}
+						<button
+							type="button"
+							class:selected={selectedTopic === option}
+							class="topic-btn"
+							onclick={() => (selectedTopic = option)}
+						>
+							{option}
+						</button>
+					{/each}
+				</div>
+				<div class="topic-actions">
+					<button
+						type="button"
+						class="primary-btn"
+						disabled={!selectedTopic}
+						onclick={() => selectedTopic && chooseTopic(selectedTopic)}
+					>
+						Bring that into the room
+					</button>
+				</div>
+			</div>
+		{:else if inputMode === 'share'}
+			<div class="control-card">
+				<p class="prompt-line">{currentPrompt}</p>
+				<UserInput
+					value={userShareText}
+					onValueChange={(next) => (userShareText = next)}
+					onSubmit={() => void handleSubmitShare()}
+					onPass={() => void handlePass()}
+					disabled={crisisResponding}
+					{crisisMode}
+					listeningOnly={data.listeningOnly}
+				/>
+			</div>
+		{:else if inputMode === 'reflection'}
+			<div class="control-card">
+				<p class="prompt-line">Meeting's over. You showed up.</p>
+				{#if summaryText}
+					<MeetingReflection summary={summaryText} />
+				{/if}
+				<div class="end-actions">
+					<a class="primary-btn link-btn" href={resolve('/')}>New meeting</a>
+				</div>
+			</div>
 		{:else}
-			<UserInput
-				value={userShareText}
-				onValueChange={(next) => (userShareText = next)}
-				onSubmit={() => submitUserShare()}
-				onPass={submitPass}
-				disabled={shouldDisableUserInput()}
-				{crisisMode}
-				listeningOnly={data.listeningOnly}
-			/>
+			<div class="control-card waiting-card" aria-hidden="true"></div>
 		{/if}
 	</section>
 </main>
 
 <style>
-	.room-shell {
-		max-width: 1300px;
+	:global(body) {
+		background:
+			radial-gradient(circle at top, rgba(196, 127, 54, 0.14), transparent 28%),
+			linear-gradient(180deg, #090d14 0%, #111827 50%, #090d14 100%);
+	}
+
+	.meeting-shell {
+		max-width: 860px;
 		margin: 0 auto;
-		padding: 1rem;
+		padding: 1rem 0.9rem 2rem;
 		display: grid;
-		grid-template-columns: 1fr;
 		gap: 0.9rem;
 	}
 
-	.room-panel {
+	.circle-wrap,
+	.transcript-wrap,
+	.input-wrap,
+	.control-card {
+		border: 1px solid rgba(167, 139, 96, 0.22);
 		border-radius: 1rem;
-		border: 1px solid rgba(158, 178, 214, 0.24);
-		background:
-			radial-gradient(circle at 86% 8%, rgba(255, 171, 68, 0.1), transparent 36%),
-			linear-gradient(170deg, rgba(9, 14, 24, 0.94), rgba(7, 10, 17, 0.88));
-		padding: 0.92rem;
+		background: rgba(11, 17, 26, 0.84);
+		backdrop-filter: blur(12px);
 	}
 
-	.room-head h1 {
-		margin: 0.25rem 0 0;
-		font-size: 1.52rem;
-		color: #ffe8bb;
+	.circle-wrap,
+	.input-wrap,
+	.control-card {
+		padding: 0.9rem;
 	}
 
-	.kicker {
-		margin: 0;
-		font-size: 0.72rem;
-		text-transform: uppercase;
-		letter-spacing: 0.12em;
-		color: #f5c87a;
-	}
-
-	.meeting-id,
-	.member-line {
-		margin: 0.35rem 0 0;
-		font-size: 0.84rem;
-		color: #d4e2fb;
-	}
-
-	.phase-pill {
-		display: inline-flex;
-		margin: 0.4rem 0 0;
-		padding: 0.22rem 0.45rem;
-		border-radius: 999px;
-		font-size: 0.72rem;
-		text-transform: uppercase;
-		letter-spacing: 0.07em;
-		background: rgba(21, 31, 51, 0.84);
-		border: 1px solid rgba(123, 156, 214, 0.34);
-		color: #d9e7ff;
-	}
-
-	.edit-grid {
-		margin-top: 0.8rem;
-		display: grid;
-		gap: 0.5rem;
-	}
-
-	.edit-grid label {
-		display: grid;
-		gap: 0.24rem;
-	}
-
-	.edit-grid span {
-		font-size: 0.72rem;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: #ffd7a0;
-	}
-
-	.edit-grid input {
-		width: 100%;
-		border-radius: 0.66rem;
-		border: 1px solid rgba(127, 149, 188, 0.36);
-		background: rgba(12, 19, 32, 0.84);
-		color: #e5eeff;
-		padding: 0.48rem 0.58rem;
-		font: inherit;
-		font-size: 0.88rem;
-	}
-
-	.edit-grid input:focus {
-		outline: 2px solid rgba(255, 195, 110, 0.66);
-		outline-offset: 1px;
-	}
-
-	.toolbar {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.45rem;
-		margin-bottom: 0.55rem;
-		align-items: center;
-	}
-
-	.toolbar-status {
-		margin: 0;
-		font-size: 0.78rem;
-		color: #cbdcf8;
-	}
-
-	.toolbar button {
-		min-height: 2.65rem;
-		padding: 0.56rem 0.75rem;
-		border-radius: 0.65rem;
-		border: 1px solid rgba(251, 191, 36, 0.38);
-		background: rgba(122, 58, 17, 0.88);
-		color: #fef3c7;
-		font: inherit;
-		font-size: 0.82rem;
-		font-weight: 700;
-		cursor: pointer;
-	}
-
-	.toolbar button:disabled {
-		opacity: 0.48;
-		cursor: not-allowed;
+	.transcript-wrap {
+		padding: 0.55rem;
+		min-height: 24rem;
 	}
 
 	.transcript-scroll {
-		margin-top: 0.55rem;
-		max-height: 34rem;
-		overflow-y: auto;
-		border-radius: 0.82rem;
-		border: 1px solid rgba(104, 122, 156, 0.32);
-		background: rgba(6, 10, 17, 0.8);
-		padding: 0.62rem;
+		max-height: 55vh;
+		overflow: auto;
+		padding: 0.2rem;
 	}
 
 	.transcript-list {
 		list-style: none;
-		padding: 0;
 		margin: 0;
+		padding: 0;
 		display: grid;
-		gap: 0.52rem;
+		gap: 0.72rem;
+	}
+
+	.inline-system {
+		list-style: none;
+	}
+
+	.action-line {
+		list-style: none;
+		padding: 0.1rem 0.2rem;
+		color: #d9c7a1;
+		font-style: italic;
+		opacity: 0.9;
+	}
+
+	.action-line p {
+		margin: 0;
+	}
+
+	.local-user-share {
+		list-style: none;
+		padding: 0.8rem;
+		border-radius: 0.82rem;
+		border: 1px solid rgba(255, 196, 112, 0.45);
+		background: rgba(37, 28, 16, 0.6);
+		color: #f9f4ea;
+	}
+
+	.local-user-share .speaker {
+		margin: 0 0 0.35rem;
+		font-size: 0.73rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: #ffd59d;
+	}
+
+	.streaming-preview {
+		list-style: none;
+		padding: 0.8rem;
+		border-radius: 0.82rem;
+		border: 1px solid rgba(245, 199, 126, 0.36);
+		background: rgba(20, 27, 39, 0.78);
+		color: #f7f2e7;
+	}
+
+	.streaming-preview p {
+		margin: 0;
+	}
+
+	.streaming-preview p + p {
+		margin-top: 0.4rem;
+		line-height: 1.55;
+	}
+
+	.prompt-line {
+		margin: 0 0 0.75rem;
+		font-size: 0.98rem;
+		line-height: 1.5;
+		color: #efe8da;
+	}
+
+	.thinking-line {
+		display: inline-flex;
+		gap: 0.32rem;
+		padding: 0.2rem 0.15rem 0.6rem;
+	}
+
+	.thinking-line span {
+		width: 0.42rem;
+		height: 0.42rem;
+		border-radius: 999px;
+		background: rgba(245, 199, 126, 0.9);
+		animation: room-pulse 1s infinite ease-in-out;
+	}
+
+	.thinking-line span:nth-child(2) {
+		animation-delay: 0.12s;
+	}
+
+	.thinking-line span:nth-child(3) {
+		animation-delay: 0.24s;
 	}
 
 	.crisis-card {
-		margin-bottom: 0.62rem;
-		padding: 0.74rem;
-		border-radius: 0.78rem;
-		border: 1px solid rgba(253, 164, 175, 0.45);
-		background: rgba(127, 29, 29, 0.24);
-		color: #fecaca;
+		margin-top: 0.8rem;
 	}
 
-	.crisis-card h2 {
+	.resource-list {
 		margin: 0;
-		font-size: 0.92rem;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
+		padding-left: 1.1rem;
+		display: grid;
+		gap: 0.35rem;
+		color: #fef3c7;
+		line-height: 1.45;
 	}
 
-	.crisis-card p {
-		margin: 0.4rem 0 0;
-		font-size: 0.85rem;
-		line-height: 1.4;
+	.primary-btn,
+	.topic-btn,
+	.link-btn {
+		font: inherit;
 	}
 
-	@media (min-width: 980px) {
-		.room-shell {
-			grid-template-columns: minmax(220px, 1fr) minmax(420px, 2fr) minmax(260px, 1fr);
-			align-items: start;
+	.primary-btn,
+	.link-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 2.9rem;
+		padding: 0.7rem 1rem;
+		border-radius: 0.78rem;
+		border: 1px solid rgba(227, 179, 97, 0.55);
+		background: rgba(148, 92, 27, 0.88);
+		color: #fff7ea;
+		font-weight: 700;
+		cursor: pointer;
+		text-decoration: none;
+	}
+
+	.topic-grid {
+		display: grid;
+		gap: 0.55rem;
+	}
+
+	.topic-btn {
+		text-align: left;
+		padding: 0.78rem 0.82rem;
+		border-radius: 0.78rem;
+		border: 1px solid rgba(131, 156, 198, 0.24);
+		background: rgba(16, 24, 36, 0.95);
+		color: #ebf1ff;
+		cursor: pointer;
+	}
+
+	.topic-btn.selected {
+		border-color: rgba(245, 199, 126, 0.58);
+		background: rgba(57, 39, 16, 0.9);
+		color: #fff7ea;
+	}
+
+	.topic-actions {
+		margin-top: 0.8rem;
+	}
+
+	.topic-btn:hover,
+	.primary-btn:hover,
+	.link-btn:hover {
+		filter: brightness(1.08);
+	}
+
+	.waiting-card {
+		min-height: 3.9rem;
+	}
+
+	.end-actions {
+		margin-top: 0.8rem;
+	}
+
+	@keyframes room-pulse {
+		0%,
+		80%,
+		100% {
+			transform: translateY(0);
+			opacity: 0.42;
 		}
 
-		.room-meta {
-			position: sticky;
-			top: 0.8rem;
+		40% {
+			transform: translateY(-0.12rem);
+			opacity: 1;
+		}
+	}
+
+	@media (min-width: 768px) {
+		.meeting-shell {
+			padding: 1.5rem 1.1rem 2.8rem;
 		}
 
-		.room-turn {
-			position: sticky;
-			top: 0.8rem;
+		.topic-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
 	}
 </style>

--- a/app/src/routes/meeting/[id]/share/+server.ts
+++ b/app/src/routes/meeting/[id]/share/+server.ts
@@ -10,23 +10,27 @@ import {
 	passesQualityValidationThresholds
 } from '$lib/core/narrative-context';
 import {
+	areIntroductionsComplete,
 	selectPromptForPhase,
 	INTRO_ORDER,
 	initializeMeetingPhase,
-	isRoundComplete,
 	recordCharacterSpoke,
 	transitionToNextPhase
 } from '$lib/core/ritual-orchestration';
 import {
 	buildCharacterSharePrompt,
+	buildCrosstalkReactionPrompt,
+	buildGoodbyePrompt,
+	buildHardQuestionPrompt,
 	buildQualityValidationPrompt,
 	buildRitualOpeningPrompt,
 	buildRitualIntroPrompt,
 	buildRitualReadingPrompt,
 	buildRitualClosingPrompt,
+	buildTopicAcknowledgmentPrompt,
 	buildTopicIntroductionPrompt
 } from '$lib/core/prompt-templates';
-import type { MeetingPhaseState } from '$lib/core/types';
+import type { CharacterProfile, MeetingPhaseState } from '$lib/core/types';
 import { MeetingPhase } from '$lib/core/types';
 import { SeamErrorCodes, err, ok, type SeamErrorCode, type SeamResult } from '$lib/core/seam';
 import type { CallbackScope, CallbackStatus, CallbackType } from '$lib/seams/database/contract';
@@ -42,7 +46,9 @@ const SHARE_INTERACTION_TYPES: readonly ShareInteractionType[] = [
 	'parallel_story',
 	'expand',
 	'crosstalk',
-	'callback'
+	'callback',
+	'hard_question',
+	'farewell'
 ];
 
 interface ShareStreamRequest {
@@ -288,66 +294,82 @@ function parseQueryRequest(url: URL): SeamResult<ShareStreamRequest> {
 	});
 }
 
-function findCharacterById(characterId: string | undefined) {
+function findCharacterById(characterId: string | undefined, characters: CharacterProfile[]) {
 	if (!characterId) return null;
-	return CORE_CHARACTERS.find((character) => character.id === characterId) ?? null;
+	return characters.find((character) => character.id === characterId) ?? null;
 }
 
-const ROUND_SPEAKER_ORDER: Record<number, string[]> = {
-	1: ['heather', 'meechie'],
-	2: ['gemini', 'gypsy'],
-	3: ['chrystal', 'marcus']
-};
-
 function pickCharacterForPhase(
-	_characterId: string | undefined,
+	characterId: string | undefined,
 	phaseState: MeetingPhaseState,
-	sequenceOrder: number
+	sequenceOrder: number,
+	interactionType: ShareInteractionType,
+	characters: CharacterProfile[]
 ) {
-	// Speaker ownership lives on the server now; ignore stale client hints.
+	const explicitCharacter = findCharacterById(characterId, characters);
+	const allowsExplicitCharacter =
+		phaseState.currentPhase === MeetingPhase.POST_MEETING ||
+		phaseState.currentPhase === MeetingPhase.SHARING_ROUND_1 ||
+		phaseState.currentPhase === MeetingPhase.SHARING_ROUND_2 ||
+		phaseState.currentPhase === MeetingPhase.SHARING_ROUND_3 ||
+		interactionType === 'crosstalk' ||
+		interactionType === 'hard_question' ||
+		interactionType === 'farewell';
+	if (explicitCharacter && allowsExplicitCharacter) {
+		return explicitCharacter;
+	}
+
 	switch (phaseState.currentPhase) {
 		case MeetingPhase.SETUP:
 		case MeetingPhase.OPENING:
-		case MeetingPhase.EMPTY_CHAIR:
-		case MeetingPhase.TOPIC_SELECTION:
 		case MeetingPhase.CLOSING:
 		case MeetingPhase.CRISIS_MODE:
-			return findCharacterById('marcus') ?? CORE_CHARACTERS[0];
+			return findCharacterById('marcus', characters) ?? characters[0];
+
+		case MeetingPhase.EMPTY_CHAIR:
+			return (
+				findCharacterById('chrystal', characters) ??
+				findCharacterById('marcus', characters) ??
+				characters[0]
+			);
+
+		case MeetingPhase.TOPIC_SELECTION:
+			return findCharacterById('marcus', characters) ?? characters[0];
 
 		case MeetingPhase.INTRODUCTIONS: {
-			const introCharacterId =
-				INTRO_ORDER[phaseState.charactersSpokenThisRound.length] ?? INTRO_ORDER[0];
-			return findCharacterById(introCharacterId) ?? CORE_CHARACTERS[0];
+			const introCharacterId = INTRO_ORDER[phaseState.charactersSpokenThisRound.length];
+			if (introCharacterId) {
+				return findCharacterById(introCharacterId, characters) ?? characters[0];
+			}
+			return (
+				characters.find(
+					(character) =>
+						character.id !== 'marcus' &&
+						!phaseState.charactersSpokenThisRound.includes(character.id)
+				) ?? characters[0]
+			);
 		}
 
 		case MeetingPhase.SHARING_ROUND_1:
 		case MeetingPhase.SHARING_ROUND_2:
 		case MeetingPhase.SHARING_ROUND_3: {
-			const roundOrder =
-				ROUND_SPEAKER_ORDER[phaseState.roundNumber ?? 1] ??
-				CORE_CHARACTERS.map((character) => character.id);
-			const nextRoundSpeaker = roundOrder.find(
-				(candidateId) => !phaseState.charactersSpokenThisRound.includes(candidateId)
+			const fallbackCharacter = characters.find(
+				(character) =>
+					character.id !== 'marcus' &&
+					!phaseState.charactersSpokenThisRound.includes(character.id)
 			);
-			if (nextRoundSpeaker) {
-				return findCharacterById(nextRoundSpeaker) ?? CORE_CHARACTERS[0];
-			}
-
-			const fallbackCharacter = CORE_CHARACTERS.find(
-				(character) => !phaseState.charactersSpokenThisRound.includes(character.id)
-			);
-			return fallbackCharacter ?? CORE_CHARACTERS[sequenceOrder % CORE_CHARACTERS.length];
+			return fallbackCharacter ?? characters[sequenceOrder % characters.length];
 		}
 
 		case MeetingPhase.POST_MEETING:
 		default:
-			return CORE_CHARACTERS[sequenceOrder % CORE_CHARACTERS.length];
+			return characters[sequenceOrder % characters.length];
 	}
 }
 
 export async function _generateValidatedShare(input: {
 	meetingId: string;
-	character: (typeof CORE_CHARACTERS)[number];
+	character: CharacterProfile;
 	prompt: string;
 	contextMessages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
 	topic: string;
@@ -478,12 +500,14 @@ function mapRecentSharesFromMeeting(
 		isUserShare: boolean;
 		content: string;
 	}>,
-	userName: string
+	userName: string,
+	characters: CharacterProfile[]
 ): Array<{ speaker: string; content: string; isUserShare: boolean }> {
 	return shares.slice(-8).map((share) => {
 		const speaker = share.isUserShare
 			? userName
-			: (CORE_CHARACTERS.find((character) => character.id === share.characterId)?.name ??
+			: (characters.find((character) => character.id === share.characterId)?.name ??
+				CORE_CHARACTERS.find((character) => character.id === share.characterId)?.name ??
 				'Character');
 		return {
 			speaker,
@@ -493,17 +517,43 @@ function mapRecentSharesFromMeeting(
 	});
 }
 
-function buildPhaseAwarePrompt(
-	character: (typeof CORE_CHARACTERS)[number],
+export function buildInteractionAwarePrompt(
+	character: CharacterProfile,
 	currentPhase: MeetingPhase,
+	interactionType: ShareInteractionType,
 	userName: string,
 	userMood: string,
 	topic: string,
 	recentShares: Array<{ speaker: string; content: string }>,
+	recentTranscript: Array<{ speaker: string; content: string; isUserShare: boolean }>,
 	heavyMemoryLines?: string[],
 	callbackLines?: string[],
 	continuityLines?: string[]
 ): string {
+	if (interactionType === 'crosstalk') {
+		return buildCrosstalkReactionPrompt(
+			character,
+			recentShares.at(-1)?.content ?? 'The room just went quiet.',
+			topic
+		);
+	}
+
+	if (interactionType === 'hard_question') {
+		const userShareHistory = recentTranscript
+			.filter((share) => share.isUserShare)
+			.map((share) => share.content)
+			.slice(-3);
+		return buildHardQuestionPrompt(userName, userShareHistory);
+	}
+
+	if (interactionType === 'farewell') {
+		return buildGoodbyePrompt(character, userName);
+	}
+
+	if (currentPhase === MeetingPhase.TOPIC_SELECTION && interactionType === 'respond_to') {
+		return buildTopicAcknowledgmentPrompt(topic);
+	}
+
 	// Select prompt type based on phase
 	const promptType = selectPromptForPhase(currentPhase, character);
 
@@ -542,6 +592,7 @@ function buildPhaseAwarePrompt(
 function createShareStream(
 	meetingId: string,
 	input: ShareStreamRequest,
+	characters: CharacterProfile[],
 	recentShares: Array<{ speaker: string; content: string; isUserShare: boolean }>,
 	locals: App.Locals
 ): Response {
@@ -586,10 +637,17 @@ function createShareStream(
 				}
 
 				const currentPhase = currentPhaseState.currentPhase;
+				const participantsResult = await locals.seams.database.getMeetingParticipants(meetingId);
+				const meetingCharacters =
+					participantsResult.ok && participantsResult.value.length > 0
+						? participantsResult.value
+						: CORE_CHARACTERS;
 				const selectedCharacter = pickCharacterForPhase(
 					input.characterId,
 					currentPhaseState,
-					input.sequenceOrder
+					input.sequenceOrder,
+					interactionType,
+					meetingCharacters
 				);
 
 				const memoryUserId = locals.userId ?? process.env.PROBE_USER_ID?.trim() ?? null;
@@ -690,13 +748,15 @@ function createShareStream(
 						);
 					}
 				}
-				const prompt = buildPhaseAwarePrompt(
+				const prompt = buildInteractionAwarePrompt(
 					selectedCharacter,
 					currentPhase,
+					interactionType,
 					userName,
 					userMood,
 					input.topic,
 					recentPromptShares,
+					recentShares,
 					heavyMemoryLines,
 					selectedCallbacks.map(formatCallbackLine),
 					mergedContinuityLines
@@ -789,18 +849,17 @@ function createShareStream(
 				}
 
 				let phaseStateAfterShare = currentPhaseState;
-				const recordCharacterResult = recordCharacterSpoke(currentPhaseState, selectedCharacter.id);
-				if (recordCharacterResult.ok) {
-					phaseStateAfterShare = recordCharacterResult.value;
-				} else {
-					console.warn(
-						`[share] recordCharacterSpoke failed for meeting=${meetingId}: ${recordCharacterResult.error.message}`
-					);
+				if (!(currentPhase === MeetingPhase.TOPIC_SELECTION && interactionType === 'standard')) {
+					const recordCharacterResult = recordCharacterSpoke(currentPhaseState, selectedCharacter.id);
+					if (recordCharacterResult.ok) {
+						phaseStateAfterShare = recordCharacterResult.value;
+					} else {
+						console.warn(
+							`[share] recordCharacterSpoke failed for meeting=${meetingId}: ${recordCharacterResult.error.message}`
+						);
+					}
 				}
 
-				const speakerCount =
-					phaseStateAfterShare.charactersSpokenThisRound.length +
-					(phaseStateAfterShare.userHasSharedInRound ? 1 : 0);
 				let transitionTrigger:
 					| 'share_complete'
 					| 'round_complete'
@@ -811,18 +870,18 @@ function createShareStream(
 				if (
 					currentPhase === MeetingPhase.OPENING ||
 					currentPhase === MeetingPhase.EMPTY_CHAIR ||
-					currentPhase === MeetingPhase.TOPIC_SELECTION ||
 					currentPhase === MeetingPhase.CLOSING ||
 					currentPhase === MeetingPhase.CRISIS_MODE
 				) {
 					transitionTrigger = 'share_complete';
-				} else if (currentPhase === MeetingPhase.INTRODUCTIONS && speakerCount >= 2) {
-					transitionTrigger = 'round_complete';
+				} else if (currentPhase === MeetingPhase.TOPIC_SELECTION) {
+					transitionTrigger = interactionType === 'respond_to' ? 'share_complete' : null;
 				} else if (
-					(currentPhase === MeetingPhase.SHARING_ROUND_1 ||
-						currentPhase === MeetingPhase.SHARING_ROUND_2 ||
-						currentPhase === MeetingPhase.SHARING_ROUND_3) &&
-					isRoundComplete(phaseStateAfterShare)
+					currentPhase === MeetingPhase.INTRODUCTIONS &&
+					areIntroductionsComplete(
+						phaseStateAfterShare,
+						Math.max(0, meetingCharacters.length - INTRO_ORDER.length)
+					)
 				) {
 					transitionTrigger = 'round_complete';
 				}
@@ -1026,13 +1085,20 @@ async function handleShareRequest(
 		}
 	}
 
+	const participantsResult = await locals.seams.database.getMeetingParticipants(meetingId);
+	const meetingCharacters =
+		participantsResult.ok && participantsResult.value.length > 0
+			? participantsResult.value
+			: CORE_CHARACTERS;
 	const recentShares = mapRecentSharesFromMeeting(
 		meetingSharesResult.value,
-		input.userName ?? 'User'
+		input.userName ?? 'User',
+		meetingCharacters
 	);
 	return createShareStream(
 		meetingId,
 		{ ...input, crisisMode: persistedCrisisMode || input.crisisMode },
+		meetingCharacters,
 		recentShares,
 		locals
 	);

--- a/app/src/routes/meeting/[id]/user-share/+server.ts
+++ b/app/src/routes/meeting/[id]/user-share/+server.ts
@@ -6,6 +6,7 @@ import {
 	type ShareInteractionType
 } from '$lib/core/meeting';
 import {
+	areIntroductionsComplete,
 	initializeMeetingPhase,
 	isRoundComplete,
 	recordUserShared,
@@ -299,14 +300,11 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
 		);
 	}
 
-	const speakerCount =
-		phaseStateAfterUserShare.charactersSpokenThisRound.length +
-		(phaseStateAfterUserShare.userHasSharedInRound ? 1 : 0);
 	let transitionTrigger: 'share_complete' | 'round_complete' | 'user_input' | 'meeting_start' | null = null;
 
 	if (currentPhase === MeetingPhase.TOPIC_SELECTION) {
 		transitionTrigger = 'user_input';
-	} else if (currentPhase === MeetingPhase.INTRODUCTIONS && speakerCount >= 2) {
+	} else if (currentPhase === MeetingPhase.INTRODUCTIONS && areIntroductionsComplete(phaseStateAfterUserShare)) {
 		transitionTrigger = 'round_complete';
 	} else if (
 		(currentPhase === MeetingPhase.SHARING_ROUND_1 ||

--- a/app/supabase/migrations/20260319_000003_restore_meeting_roster_and_share_interactions.sql
+++ b/app/supabase/migrations/20260319_000003_restore_meeting_roster_and_share_interactions.sql
@@ -1,0 +1,30 @@
+alter table public.meeting_participants
+	add column if not exists seat_order integer;
+
+update public.meeting_participants
+set seat_order = 0
+where seat_order is null;
+
+alter table public.meeting_participants
+	alter column seat_order set not null;
+
+create unique index if not exists idx_meeting_participants_meeting_seat_order
+	on public.meeting_participants (meeting_id, seat_order);
+
+alter table public.shares
+	drop constraint if exists shares_interaction_type_check;
+
+alter table public.shares
+	add constraint shares_interaction_type_check check (
+		interaction_type in (
+			'standard',
+			'respond_to',
+			'disagree',
+			'parallel_story',
+			'expand',
+			'crosstalk',
+			'callback',
+			'hard_question',
+			'farewell'
+		)
+	);

--- a/app/tests/composition/meeting-flow.spec.ts
+++ b/app/tests/composition/meeting-flow.spec.ts
@@ -4,6 +4,7 @@ import { buildPromptContext } from '$lib/core/memory-builder';
 import { scanForCallbacks } from '$lib/core/callback-scanner';
 import { addShare, closeMeeting, createMeeting } from '$lib/core/meeting';
 import { SeamErrorCodes, err, ok } from '$lib/core/seam';
+import type { MeetingParticipant } from '$lib/core/types';
 import type {
 	CallbackRecord,
 	CallbackScope,
@@ -26,6 +27,7 @@ interface InMemoryState {
 	meetings: MeetingRecord[];
 	shares: ShareRecord[];
 	callbacks: CallbackRecord[];
+	participants: MeetingParticipant[];
 	ids: {
 		meeting: number;
 		share: number;
@@ -52,6 +54,7 @@ function createInMemoryDatabase(userId: string): { state: InMemoryState; databas
 		meetings: [],
 		shares: [],
 		callbacks: [],
+		participants: [],
 		ids: { meeting: 0, share: 0, callback: 0 }
 	};
 
@@ -102,6 +105,18 @@ function createInMemoryDatabase(userId: string): { state: InMemoryState; databas
 			return ok(meeting);
 		},
 
+		async saveMeetingParticipants(input) {
+			state.participants = input.participants.map((participant) => ({
+				...participant,
+				sharesCount: 0
+			}));
+			return ok(state.participants);
+		},
+
+		async getMeetingParticipants() {
+			return ok(state.participants);
+		},
+
 		async appendShare(input) {
 			state.ids.share += 1;
 			const share: ShareRecord = {
@@ -110,6 +125,7 @@ function createInMemoryDatabase(userId: string): { state: InMemoryState; databas
 				characterId: input.characterId,
 				isUserShare: input.isUserShare,
 				content: input.content,
+				interactionType: input.interactionType,
 				significanceScore: input.significanceScore,
 				sequenceOrder: input.sequenceOrder,
 				createdAt: isoNow(state.ids.share * 1000)

--- a/decision-log.md
+++ b/decision-log.md
@@ -1,5 +1,12 @@
 # Decision Log
 
+## 2026-03-19
+
+- The virtual-meeting restore will use a meeting-scoped persisted participant roster as the source of truth, not client-only fake `random1` / `random2` speakers.
+- The roster restore needs a real persistence story: database-created visitor character ids plus `seat_order` on `meeting_participants`, not synthetic selector ids pretending to be database ids.
+- Opening, reading, and introduction beats remain phase-driven in the share route; `crosstalk`, `hard_question`, and `farewell` are the interaction-type additions that must be wired and persisted truthfully.
+- Listening-only remains a supported mode in the restore: the user still joins, introduces themself, and chooses a topic, but later share gates and the hard question are skipped.
+
 ## 2026-02-15
 
 - Repository execution will follow `plans/the-14th-step-execplan.md` as the canonical working plan.
@@ -28,6 +35,10 @@
 - Added a dedicated `database.completeMeeting` seam operation to persist close-state metadata through the adapter boundary instead of writing close updates directly inside route handlers.
 - Enforced Milestone 6 retrieval logic in the pure memory-builder core (rather than adapter-only filtering) so memory rules remain deterministic and testable with fixture/mocked seam inputs.
 - Retained `getHeavyMemory` seam name but shifted semantics to return ordered user meeting-share history; rule selection now occurs in `memory-builder` to support last-3-meetings continuity and prompt composition.
+- Treated the meeting restore as a backend-truth problem first: interaction types, roster persistence, and phase ownership were wired through the seam before trusting the page rewrite.
+- Split `topic_selection` into two durable beats without inventing a new phase: `standard` now keeps Marcus in the topic-setting beat, while `respond_to` acknowledges the chosen topic and advances the room.
+- Accepted a bounded stop rule on refresh recovery: pending user gates and fresh post-user transitions resume truthfully, while fully replay-free mid-beat auto-resume is deferred until the ritual state model can encode more substep detail.
+- Kept the remaining Svelte 5 rune warnings explicit instead of pretending they were harmless noise; they are logged as deferred cleanup, not hidden under a green test run.
 
 ## 2026-02-19
 
@@ -66,6 +77,7 @@
 - Renamed route-test helper export in `app/src/routes/meeting/[id]/share/+server.ts` to `_generateValidatedShare` to comply with SvelteKit endpoint export validation rules while preserving direct route-module test coverage.
 - Increased Playwright `webServer.timeout` from `180000` to `300000` after measuring local `npm run build` wall time (~2m12s) and confirming the previous timeout created false e2e startup failures in this workspace.
 - Accepted a local closeout exception for `npm run check` root-cause diagnosis (silent `svelte-check` stall) while still requiring fallback verification lanes (`tsc`, contracts/core/composition tests, build, and Playwright e2e) to pass and be documented.
+- Moved the room-restoration work into the seam/persistence layers before touching the meeting page: persisted roster bootstrap in `+page.server.ts`, preserved `interactionType` end-to-end, and corrected the share route so introductions complete on the full roster and sharing rounds advance on the user turn instead of the second character share.
 
 ## 2026-03-04
 

--- a/plans/production-recovery-and-backlog-execplan.md
+++ b/plans/production-recovery-and-backlog-execplan.md
@@ -24,10 +24,14 @@ This plan also assumes a high-agency implementation style. The executing agent s
 - [x] (2026-03-18 09:50Z) Opened PR `#69` (`fix(auth): harden Clerk session cookie selection`) to address the review follow-up where multiple Clerk session cookies should be tried in order instead of failing on the first stale token.
 - [x] (2026-03-18 20:10Z) Confirmed that all three production Postgres URLs (`POSTGRES_URL`, `POSTGRES_PRISMA_URL`, `POSTGRES_URL_NON_POOLING`) fail with `Tenant or user not found`, so the direct pooler path is not a viable unattended recovery target.
 - [x] (2026-03-18 20:12Z) Confirmed Supabase CLI is not installed on this machine and there is no saved Supabase auth/config, so a fresh Supabase reprovision cannot be completed autonomously from the current environment.
+- [x] (2026-03-18 20:45Z) Landed the bounded issue `#10` hardening slice on branch `codex/narrative-context-hardening-2026-03-18` and opened draft PR `#70` (`fix(core): harden narrative context fallback handling`).
+- [x] (2026-03-18 20:50Z) Commented a concrete prompt-surface inventory onto issue `#17`, including grouped runtime surfaces and the smallest safe follow-up slices.
+- [x] (2026-03-18 20:53Z) Opened issue `#71` to track production database backend reprovisioning as the current external blocker.
 - [ ] Provision or recover a real production database target, apply the existing schema, and update the live Vercel project to use it.
 - [ ] Land the minimum production recovery change or env update, redeploy, and verify both guest and member meeting start on the real public site.
 - [ ] Merge or close PR `#69` after the production recovery decision is made so auth work does not linger as half-finished local state.
-- [ ] After production is stable, mine the next two bounded backlog slices in parallel: issue `#10` as implementation work and issue `#17` as analysis/inventory work.
+- [ ] Review and ship or revise draft PR `#70` after a trustworthy narrow test/build pass is available.
+- [ ] After production is stable, turn the issue `#17` inventory into the next 2-3 prompt-writing slices instead of one giant rewrite.
 
 ## Surprises & Discoveries
 
@@ -76,6 +80,10 @@ This plan also assumes a high-agency implementation style. The executing agent s
 
 - Decision: Treat production recovery as externally blocked pending a newly provisioned database target, and use the blocked time to mine bounded backlog work that does not overlap the database outage.
   Rationale: The remaining work that can be done autonomously with high confidence is code hardening and diagnosis on slices that do not depend on the dead backend.
+  Date/Author: 2026-03-18 / Codex
+
+- Decision: Convert backlog work into durable artifacts while production is blocked: a real PR for issue `#10`, an issue comment inventory for issue `#17`, and a first-class outage issue for the missing backend.
+  Rationale: This keeps momentum without pretending the live outage is fixed, and it prevents the blocked time from collapsing into undocumented local analysis.
   Date/Author: 2026-03-18 / Codex
 
 - Decision: Keep backlog mining strictly secondary to production recovery.

--- a/plans/production-recovery-and-backlog-execplan.md
+++ b/plans/production-recovery-and-backlog-execplan.md
@@ -1,0 +1,312 @@
+# Restore Production Reliability And Mine The Next Safe Backlog Slices
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with [PLANS.md](/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/PLANS.md).
+
+## Purpose / Big Picture
+
+The immediate goal is to make `https://14thstep.com` reliably usable again for real people. After the work in this plan is complete, a guest or member should be able to open the site, start a meeting, and see the meeting continue into actual room behavior instead of failing during authentication or bootstrap. Once production is stable, the same workflow should keep moving forward by landing the smallest safe backlog slices instead of reopening large messy branches.
+
+The plan is intentionally ordered around user-visible recovery first, then merge hygiene, then backlog throughput. The site being healthy matters more than new features. After production is healthy, the work should continue in small decision-gated slices so local work, GitHub, and Vercel remain synchronized.
+
+This plan also assumes a high-agency implementation style. The executing agent should be decisive, should not stop for routine ambiguity, and should prefer the clean root-cause fix over timid symptom-patching. The only acceptable reason to pause is a true external blocker such as missing credentials, destructive irreversible risk, or the need for a user-owned production secret that cannot be inferred safely.
+
+## Progress
+
+- [x] (2026-03-18 09:50Z) Confirmed the live Vercel production project is `app` and that the public domains `14thstep.com`, `www.14thstep.com`, and `the14thstep.vercel.app` point to deployment `dpl_44ARFMByHcJhKrTCXgjEyieVJ8DH`.
+- [x] (2026-03-18 09:50Z) Merged the Clerk session-cookie hotfix as PR `#68` / commit `b7bcdd8`, which fixed the member-session issue where Clerk suffixed cookies such as `__session_*` were ignored by the server.
+- [x] (2026-03-18 09:50Z) Confirmed the user rotated the xAI key and that Vercel reported a fresh successful production deployment after the rotation.
+- [x] (2026-03-18 09:50Z) Reproduced the remaining live failure: landing page loads, but guest bootstrap still returns `503` on production.
+- [x] (2026-03-18 09:50Z) Pulled production env from the real live `app` Vercel project at the repo root and confirmed that `SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_URL` still point at `https://tmcpfhftdrexsjrcrxbo.supabase.co`.
+- [x] (2026-03-18 09:50Z) Confirmed the stale project ref `tmcpfhftdrexsjrcrxbo` is also encoded into the current `SUPABASE_SERVICE_ROLE_KEY`.
+- [x] (2026-03-18 09:50Z) Confirmed the direct Postgres pooler host in `POSTGRES_URL` resolves, while the Supabase REST host does not.
+- [x] (2026-03-18 09:50Z) Opened PR `#69` (`fix(auth): harden Clerk session cookie selection`) to address the review follow-up where multiple Clerk session cookies should be tried in order instead of failing on the first stale token.
+- [x] (2026-03-18 20:10Z) Confirmed that all three production Postgres URLs (`POSTGRES_URL`, `POSTGRES_PRISMA_URL`, `POSTGRES_URL_NON_POOLING`) fail with `Tenant or user not found`, so the direct pooler path is not a viable unattended recovery target.
+- [x] (2026-03-18 20:12Z) Confirmed Supabase CLI is not installed on this machine and there is no saved Supabase auth/config, so a fresh Supabase reprovision cannot be completed autonomously from the current environment.
+- [ ] Provision or recover a real production database target, apply the existing schema, and update the live Vercel project to use it.
+- [ ] Land the minimum production recovery change or env update, redeploy, and verify both guest and member meeting start on the real public site.
+- [ ] Merge or close PR `#69` after the production recovery decision is made so auth work does not linger as half-finished local state.
+- [ ] After production is stable, mine the next two bounded backlog slices in parallel: issue `#10` as implementation work and issue `#17` as analysis/inventory work.
+
+## Surprises & Discoveries
+
+- Observation: The repo root and `/home/latro/The14thstep` are linked to the healthy Vercel `app` project, but `app/.vercel/project.json` inside this checkout still points to the retired `the14thstep` project.
+  Evidence: The root `.vercel/project.json` contains `"projectName":"app"` while `app/.vercel/project.json` contains `"projectName":"the14thstep"`. Use the repo root, not `app/`, for Vercel env inspection and env mutation.
+
+- Observation: The remaining live failure is not the Clerk cookie hotfix and not the rotated xAI key.
+  Evidence: `gh api repos/Phazzie/The14thstep/commits/b7bcdd8361a5809ae45aebc2f87ad7540219492a/status` reports Vercel success for the hotfix deploy, but `vercel logs https://14thstep.com --no-follow --json` still shows `POST /` returning `503`.
+
+- Observation: The live project is configured with a Supabase project ref that no longer resolves as a REST host.
+  Evidence: `vercel env pull` from the root-linked `app` project shows `SUPABASE_URL="https://tmcpfhftdrexsjrcrxbo.supabase.co"`, and direct bootstrap probing failed with `getaddrinfo ENOTFOUND tmcpfhftdrexsjrcrxbo.supabase.co`.
+
+- Observation: The direct Postgres pooler host in the same production env is still DNS-resolvable.
+  Evidence: `getent hosts aws-1-us-east-1.pooler.supabase.com` returns live addresses while `getent hosts tmcpfhftdrexsjrcrxbo.supabase.co` returns nothing.
+
+- Observation: The DNS-resolvable pooler host is not enough to recover production because every live Postgres URL still points at a dead tenant.
+  Evidence: Probing `POSTGRES_URL`, `POSTGRES_PRISMA_URL`, and `POSTGRES_URL_NON_POOLING` with the `pg` client against the live pulled env returned `Tenant or user not found` / `XX000` for all three URLs.
+
+- Observation: Autonomous Supabase reprovisioning is blocked by missing local Supabase tooling and auth, not by uncertainty about what the app needs.
+  Evidence: `supabase --version` fails with `command not found`, and there is no `~/.supabase` or `~/.config/supabase` state on disk.
+
+- Observation: The production guest flow surfaces `503` from the server, but the browser-level auth warning is only incidental.
+  Evidence: Playwright against the public site reaches `/?/continueGuest`, and `vercel logs` show `responseStatusCode:503` with `[auth.session] unresolved code=UNAUTHORIZED message=No active auth session` on the same POST. The unresolved auth line is expected before bootstrap; the real failure is the `503` during the action.
+
+## Decision Log
+
+- Decision: Treat production recovery as a database-path problem, not an auth/UI problem.
+  Rationale: The Clerk cookie bug is already merged and deployed. The remaining production `503` persists after that fix and after xAI rotation, so continuing to tweak auth or prompts would be drift.
+  Date/Author: 2026-03-18 / Codex
+
+- Decision: Use the repo root for all future Vercel environment inspection and mutation.
+  Rationale: The nested `app/.vercel/project.json` still points to the retired `the14thstep` project and will mislead any future environment work.
+  Date/Author: 2026-03-18 / Codex
+
+- Decision: Prefer restoring a valid backend reference over a large adapter rewrite.
+  Rationale: Swapping the database seam from Supabase REST to direct Postgres can be done cleanly, but it is still a meaningful architectural change. The least-debt fix is to restore a valid existing backend if one is available.
+  Date/Author: 2026-03-18 / Codex
+
+- Decision: If no valid Supabase REST project can be restored from available credentials and local context, implement a clean Postgres-backed `DatabasePort` adapter rather than patching around the dead REST host.
+  Rationale: The direct Postgres pooler host still resolves, and the current code already separates database access behind `DatabasePort`. A real adapter is acceptable; ad hoc route-level SQL would be debt.
+  Date/Author: 2026-03-18 / Codex
+
+- Decision: Do not continue building a Postgres-backed production adapter against the currently configured production credentials.
+  Rationale: The live Postgres URLs are not merely using the wrong transport; they all fail with `Tenant or user not found`, so there is no actual database target to restore against. Building the adapter now would create speculative code without an operational backend.
+  Date/Author: 2026-03-18 / Codex
+
+- Decision: Treat production recovery as externally blocked pending a newly provisioned database target, and use the blocked time to mine bounded backlog work that does not overlap the database outage.
+  Rationale: The remaining work that can be done autonomously with high confidence is code hardening and diagnosis on slices that do not depend on the dead backend.
+  Date/Author: 2026-03-18 / Codex
+
+- Decision: Keep backlog mining strictly secondary to production recovery.
+  Rationale: The site is currently broken for real users, so backlog work should only begin after guest/member start flows are verified live.
+  Date/Author: 2026-03-18 / Codex
+
+## Outcomes & Retrospective
+
+This section is not complete yet. The current state is that auth reliability improved materially with PR `#68`, but production still has a backend bootstrap outage because the configured backend no longer exists. The main lesson so far is that project-link drift (`app/.vercel` vs root `.vercel`) and env drift can masquerade as app bugs, and that a resolvable host is not the same thing as a live database. The next contributor should assume that external state is part of the bug until proven otherwise.
+
+## Context and Orientation
+
+The application is a SvelteKit app in `app/`. The public production site is served by Vercel project `app`, not by the retired project `the14thstep`. The live root checkout for Vercel commands is the repository root `/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run`, not `/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/app`.
+
+The user-visible entry point is `app/src/routes/+page.svelte` and `app/src/routes/+page.server.ts`. Guests click `Continue as Guest`; members use Clerk sign-in/sign-up. The server creates request-scoped seams in `app/src/hooks.server.ts`. Those seams include:
+
+- `auth`, implemented in `app/src/lib/server/seams/auth/adapter.ts`
+- `database`, implemented in `app/src/lib/server/seams/database/adapter.ts`
+- `grokAi`, implemented in `app/src/lib/server/seams/grok-ai/adapter.ts`
+
+The important production facts right now are:
+
+- PR `#68` is merged to `main` as commit `b7bcdd8` and deployed.
+- PR `#69` exists to harden multi-cookie Clerk session selection and is not part of the immediate production outage.
+- The live site still returns `503` during guest bootstrap.
+- The live Vercel `app` project currently has:
+  - `SUPABASE_URL="https://tmcpfhftdrexsjrcrxbo.supabase.co"`
+  - `NEXT_PUBLIC_SUPABASE_URL="https://tmcpfhftdrexsjrcrxbo.supabase.co"`
+  - `POSTGRES_URL="postgres://postgres.tmcpfhftdrexsjrcrxbo:...@aws-1-us-east-1.pooler.supabase.com:6543/postgres?..."`
+- The Supabase REST host is dead, and every configured Postgres URL also fails with `Tenant or user not found`.
+
+The phrase "decision-gated promotion" means: prove a change locally, push a small PR, handle review, merge, and only then begin the next slice. This repository already uses that workflow and it should continue.
+
+The phrase "subagent" means a separate smaller agent thread used in parallel for bounded work. In this plan, subagents are used for exploration, log collection, and non-overlapping backlog slices; the main agent remains the final integrator.
+
+This plan uses three review phrases in a precise way:
+
+- A "root-cause review" means asking whether the proposed fix attacks the actual failure source or only a surface symptom.
+- A "harsh but fair critique" means deliberately arguing against the chosen fix as if reviewing it for regressions, shortcuts, or architecture drift.
+- An "architecture review" means checking whether the change belongs at the seam, adapter, route, or UI layer, and rejecting fixes that solve the bug in the wrong layer.
+
+## Plan of Work
+
+The work is divided into two large phases: recover production first, then mine safe backlog slices.
+
+The first production milestone begins with proof, not code. From the repo root, pull the real `app` production env into a temp file and verify the Supabase values. Then try to discover whether a valid current Supabase REST project exists anywhere accessible from local context. Search all checked-in env examples, docs, handoff files, and linked local repos for a different active project ref or host. Before changing anything, write a short root-cause note in this plan that answers three questions in plain language: what is broken, what evidence proves it, and what are the two or three most plausible repair paths. After that note exists, run a harsh but fair critique against those candidate paths and explicitly reject the weaker ones.
+
+That root-cause review is now settled: the production environment points at a deleted or otherwise dead Supabase tenant. The evidence is direct and redundant: the REST hostname does not resolve, the service-role token is still tied to that dead ref, all three Postgres URLs fail with `Tenant or user not found`, and no alternate live project ref exists in local context. The only clean repair paths left are to reprovision a real backend target or to wait until one is provided.
+
+If a current valid project ref is found, update the live Vercel `app` project envs (`SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, and any matching Supabase publishable/anon values if they are tied to the project) to the correct values and redeploy. Re-run the live guest and member flows after the deploy. If both flows work, skip the adapter rewrite entirely. Do not continue into a larger code change once the smaller configuration fix is proven.
+
+If no valid Supabase REST project can be found from accessible local/remote state, the second production milestone is to replace the broken server database transport cleanly. Before writing code, do an architecture review and answer: why is an adapter-level change the right layer, what would be wrong about route-level SQL, and what are the risks of choosing direct Postgres as the primary transport. Once that review is written, add a new adapter module under `app/src/lib/server/seams/database/` that implements `DatabasePort` over the direct Postgres pooler connection from `POSTGRES_URL`. Keep the existing Supabase-backed adapter intact and give the code a clear selection point: either add a `createSupabaseDatabaseAdapter` export for the current code and introduce `createPostgresDatabaseAdapter`, or move shared row-mapping helpers into a shared module and let `createDatabaseAdapter()` choose the transport. Do not scatter SQL across routes. The seam boundary must stay intact.
+
+The Postgres-backed adapter must fully support the methods actually used in the live runtime: `getUserById`, `ensureUserProfile`, `createMeeting`, `appendShare`, `getMeetingShares`, `getHeavyMemory`, `getShareById`, `updateMeetingPhase`, `getMeetingPhase`, `createCallback`, `getActiveCallbacks`, `markCallbackReferenced`, `completeMeeting`, `updateCallback`, and `getMeetingCountAfterDate`. The current Supabase adapter is the specification for behavior and error mapping; port the semantics, not just the SQL. Reuse the validation helpers in `app/src/lib/seams/database/contract.ts` and the seam error mapping style from the existing adapter. Prefer one new shared module for row mappers and one transport-specific adapter rather than duplicating the entire file.
+
+After the production path is fixed, redeploy from `main`, then run live browser verification against `https://14thstep.com`. Use one guest flow and one member flow. A valid result is not merely "page loads"; it is: the user reaches `/meeting/<id>`, the room UI appears, and after a brief wait the room begins speaking instead of dying in bootstrap. Before merge, run a final harsh but fair critique on the exact shipped diff and answer: what shortcut would a lazy fix have taken here, and how does the chosen fix avoid that shortcut.
+
+Only after that should backlog mining begin. Each backlog slice must repeat the same discipline: diagnose first, enumerate at least two candidate fixes or approaches, write a harsh but fair critique of the leading option, then implement the smallest root-cause fix that survives critique. The first implementation slice should be issue `#10`, which is bounded and code-oriented: harden narrative-context generator error handling and fallback cache behavior. The second slice should be issue `#17`, but only as an analysis/inventory pass first. That pass should identify every prompt surface and propose a minimal follow-up change list; it should not rewrite all prompt logic in one go. Issues `#7` and `#8` remain product-decision-heavy and should stay deferred unless the restored live behavior provides enough evidence to settle them.
+
+## Autonomous Execution, Review, And Quality Gates
+
+This section is the operating spine of the plan. The main agent should follow it for production recovery and for every later backlog slice.
+
+Start every slice with a diagnosis memo written into this plan. That memo must explain the problem in plain language, list the evidence, and name at least two plausible fixes. One of those fixes may be "do nothing yet" if the evidence is too weak. Then write a harsh but fair critique of the most tempting fix. The critique must actively look for symptom-patching, wrong-layer changes, regressions, hidden coupling, and merge-risk. If the critique exposes a fatal weakness, revise the plan before changing code.
+
+After diagnosis and critique, do an architecture review. The architecture review must answer which layer owns the problem in this repository. In this codebase the allowed strong layers are seams, adapters, core logic, route handlers, and UI. Fixes should land in the highest-leverage correct layer. For example, a dead database transport belongs in a database adapter, not in a route-level conditional. A session-cookie parsing bug belongs in auth/session helpers, not in every route.
+
+Once the architecture layer is chosen, the main agent should make a decisive call and proceed. "Decisive" here means choosing a path and executing it fully, not continuing to hedge after the evidence is strong. The agent should still be brave enough to choose a bigger but cleaner fix when the smaller one is obviously wrong. Avoid the false virtue of minimalism when minimalism would preserve the bug.
+
+Subagents should be used in parallel but with disjoint scopes. One explorer should gather live evidence. Another explorer should challenge assumptions or inspect schema/runtime details. Workers should only edit disjoint code areas. The main agent owns the final diff, the final test selection, the final PR, and the final merge decision.
+
+Before every PR, run a merge-readiness review. That review must ask:
+
+- Does this change fix the root cause or just hide it?
+- Does it reduce architectural debt, preserve it, or increase it?
+- Are the tests proving the real behavior, or only proving the code moved?
+- Is there a smaller or cleaner seam-level change that would have been better?
+- What is the most likely regression, and how was it checked?
+
+After every merge, update this plan's `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` sections immediately. Then re-base the next step on the new `main`, not on stale local residue.
+
+## Concrete Steps
+
+Work from the repository root unless a step explicitly says `app/`.
+
+First, verify and snapshot the current production state:
+
+    cd /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run
+    npx vercel inspect https://14thstep.com
+    gh api repos/Phazzie/The14thstep/commits/main/status
+    npx vercel logs https://14thstep.com --no-follow --json
+
+Expected result: Vercel reports a ready production deployment, GitHub shows the latest `main` deployment status as success, and logs still show `POST /` failures when the guest flow is attempted.
+
+Then pull the real production env from the live `app` project. This must be run from the repo root, not `app/`:
+
+    cd /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run
+    npx vercel env pull /tmp/live-app-prod.env --environment production
+    grep -E '^(SUPABASE_URL|NEXT_PUBLIC_SUPABASE_URL|POSTGRES_HOST|POSTGRES_URL)=' /tmp/live-app-prod.env
+
+Expected result: the Supabase REST host still points at `tmcpfhftdrexsjrcrxbo.supabase.co`.
+
+To see whether a current valid Supabase project is already known anywhere locally, search repo and sibling worktrees:
+
+    rg -n 'supabase.co|SUPABASE_URL|NEXT_PUBLIC_SUPABASE_URL|project ref' \
+      /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run \
+      /home/latro/The14thstep \
+      -g '!**/node_modules/**' -g '!**/.svelte-kit/**'
+
+If a different live project ref is found and can be trusted, update the Vercel `app` project env through the root-linked checkout and redeploy:
+
+    cd /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run
+    printf '%s' 'https://<correct-project-ref>.supabase.co' | npx vercel env add SUPABASE_URL production
+    printf '%s' 'https://<correct-project-ref>.supabase.co' | npx vercel env add NEXT_PUBLIC_SUPABASE_URL production
+    npx vercel --prod
+
+If no valid REST host can be restored, do not proceed straight to a Postgres-backed seam implementation. First, probe every configured Postgres URL. If they fail to authenticate or return `Tenant or user not found`, stop and mark the database itself as externally blocked instead of building an adapter against a dead backend.
+
+Only if a real working Postgres target exists should work continue into a Postgres-backed seam implementation. At that point, create a new adapter module in `app/src/lib/server/seams/database/` and a shared helper module if needed. Add the Postgres client dependency in `app/package.json`, install it, and implement the adapter over the live `POSTGRES_URL`. Keep the existing Supabase adapter in place for comparison and tests. Update `app/src/hooks.server.ts` or the database adapter entry point so production chooses the transport deterministically and safely.
+
+After the code path changes, run the narrowest verification first:
+
+    cd /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/app
+    npx vitest run src/lib/server/seams/database/adapter.spec.ts
+    npm run build
+
+Then run live verification using a real browser against the public site. Use a script or Playwright CLI, but the observable behavior must be:
+
+    1. Open https://14thstep.com
+    2. Click Continue as Guest
+    3. Complete the 4-step setup flow
+    4. Submit Join Meeting
+    5. Observe redirect to /meeting/<id>
+    6. Wait up to 20 seconds and observe room content appearing
+
+For member verification, repeat with a real test account or a newly created one. A valid result is not only successful login; it is successful meeting start.
+
+After local verification but before PR, run one red-team pass through a subagent or separate review thread. That review should inspect only the proposed diff and should be instructed to find the strongest reason the fix should not ship. Address immediate findings before opening the PR.
+
+Once production is healthy, continue with the first backlog slice:
+
+    cd /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run
+    gh issue view 10
+
+Implement only the narrative-context hardening work in a fresh branch from updated `main`, verify it, open a PR, and merge it before starting the next issue.
+
+Then do the issue `#17` analysis slice:
+
+    cd /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run
+    gh issue view 17
+
+Produce a prompt-surface inventory, a recommendation, and either a PR with documentation-only guidance or a follow-up issue expansion if code changes are not yet justified.
+
+## Validation and Acceptance
+
+Production recovery is accepted only if all of the following are true:
+
+- `https://14thstep.com` loads and the landing page presents guest/member entry points.
+- A guest can click `Continue as Guest`, complete setup, submit `Join Meeting`, and reach a meeting URL without a `503`.
+- A member can sign in or sign up and also reach a meeting URL without bootstrap failure.
+- After reaching `/meeting/<id>`, the room continues into actual content. The meeting does not stall before AI output.
+- `vercel logs https://14thstep.com --no-follow --json` no longer shows the guest/member bootstrap `503` for the tested flows.
+
+The fallback adapter path is accepted only if:
+
+- The database seam behavior matches the existing contract semantics.
+- The app builds successfully with `npm run build`.
+- Focused tests for the database seam pass.
+- Live browser verification on production succeeds for both guest and member entry.
+
+Backlog mining is accepted only if each slice is shipped as its own PR and leaves `main` deployable after merge.
+
+No slice is accepted if the only proof is unit tests. Each production-facing slice must include one human-verifiable behavior check or a real runtime log check that demonstrates the user-visible improvement.
+
+## Idempotence and Recovery
+
+All Vercel env inspection commands are safe to repeat. `vercel env pull` can be run repeatedly to refresh `/tmp/live-app-prod.env`; it should not be committed.
+
+If env mutation is needed, always update the `app` project from the repo root. Do not run Vercel env commands from `app/` because that nested directory is still linked to the retired `the14thstep` project.
+
+If a valid Supabase REST host is found and applied, redeploy before testing. If the redeploy makes production worse, restore the previous env values from the pulled temp file and redeploy again.
+
+If the Postgres-backed adapter path is chosen, keep the existing Supabase adapter alongside it until production verification passes. This is an intentional parallel implementation to reduce risk. Retire the broken transport only after the new path is proven live.
+
+If the direct Postgres path cannot authenticate or the underlying database is unreachable, stop and record that in `Surprises & Discoveries`. At that point the external backend itself is unavailable, and the next step requires either a restored Supabase project or a new production database provisioned by the user.
+
+If review feedback identifies a real wrong-layer fix, do not defend the existing patch out of sunk-cost loyalty. Rewrite or replace it while the slice is still small. This plan explicitly prefers correctness and clean architecture over preserving already-written code.
+
+## Artifacts and Notes
+
+These short evidence snippets are the current grounding for the plan:
+
+    Root-linked live project:
+      /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/.vercel/project.json
+      {"projectId":"prj_JvQ6xLJe0Pfpp1pdJc8mcA1TyMeo","projectName":"app"}
+
+    Nested stale project link:
+      /mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/app/.vercel/project.json
+      {"projectId":"prj_z7nTd2jFUKwI9rvpgUeqKjocIzOS","projectName":"the14thstep"}
+
+    Live env from the real project:
+      NEXT_PUBLIC_SUPABASE_URL="https://tmcpfhftdrexsjrcrxbo.supabase.co"
+      SUPABASE_URL="https://tmcpfhftdrexsjrcrxbo.supabase.co"
+      POSTGRES_URL="postgres://postgres.tmcpfhftdrexsjrcrxbo:...@aws-1-us-east-1.pooler.supabase.com:6543/postgres?..."
+
+    Live production failure:
+      vercel logs https://14thstep.com --no-follow --json
+      {"requestMethod":"POST","requestPath":"/","responseStatusCode":503,"message":"[auth.session] unresolved code=UNAUTHORIZED message=No active auth session"}
+
+    Direct DNS evidence:
+      getent hosts tmcpfhftdrexsjrcrxbo.supabase.co
+      <no output>
+
+      getent hosts aws-1-us-east-1.pooler.supabase.com
+      3.227.209.82 ...
+
+## Interfaces and Dependencies
+
+If the Postgres fallback path is used, add exactly one server-side database client dependency to `app/package.json`. Prefer a mature driver that works well in Node 24 and serverless environments. The new transport must still implement the existing `DatabasePort` from `app/src/lib/seams/database/contract.ts`; do not change route code to know or care which backend transport is used.
+
+Subagent routing for autonomous continuation should follow this split:
+
+- Subagent `Aristotle` (explorer): production state collection, Vercel deployment/env/log verification, and precise evidence gathering.
+- Subagent `Ampere` (explorer): backend proof-of-life exploration for the direct Postgres path, including schema inspection and SQL query shape planning.
+- Subagent `Kant` (worker): if the Postgres path is chosen, implement user/profile/meeting bootstrap methods (`getUserById`, `ensureUserProfile`, `createMeeting`) plus the smallest supporting helpers.
+- Subagent `Faraday` (worker): if the Postgres path is chosen, implement the share/callback/phase methods in a disjoint write scope and add or update the relevant tests.
+
+After production recovery is complete, subagent usage for backlog mining should be:
+
+- One worker on issue `#10` implementation.
+- One explorer on issue `#17` prompt-surface inventory and recommendation.
+- The main agent keeps integration ownership and merge-readiness checks.
+
+Revision note (2026-03-18 / Codex): Created this plan after confirming that the merged Clerk auth fix is live, the xAI key has been rotated, and the remaining production outage is tied to the stale Supabase project ref still configured in the real `app` Vercel project. Revised the plan the same day to add explicit root-cause review, harsh-critique loops, architecture review gates, red-team review before PRs, and a higher-agency standard for decisive implementation.

--- a/plans/restore-virtual-recovery-meeting-execplan.md
+++ b/plans/restore-virtual-recovery-meeting-execplan.md
@@ -1,0 +1,1212 @@
+# Restore the Virtual Recovery Meeting
+
+This ExecPlan is a living document. Keep `Progress`, `Surprises & Discoveries`, `Decision Log`, `Outcomes & Retrospective`, and the revision note at the bottom current as work proceeds. Maintain this file in accordance with [PLANS.md](/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/PLANS.md).
+
+## Purpose / Big Picture
+
+After this work, a person can open `/`, answer the intake questions, click `Join Meeting`, and then stop touching the screen. The meeting starts on its own, runs like a room instead of a control panel, pauses where it should pause, asks for the user only when the room would ask, and closes like a meeting instead of an app flow.
+
+The deliverable is not "a nicer meeting page." The deliverable is that the page once again behaves like a living meeting. The user is no longer the operator. The room runs.
+
+## Experience Target
+
+The target experience is plain:
+
+- the user enters a first name or alias, clean time, mood, and optional "what's on your mind"
+- the user clicks `Join Meeting`
+- the meeting starts without another click
+- Marcus speaks first and says the user's name
+- the room pauses on purpose
+- Chrystal reads
+- everyone introduces themself
+- the room settles and waits
+- the user introduces themself
+- Marcus asks what they want to talk about
+- the user chooses from a fixed topic list
+- the room runs three rounds, with the characters carrying most of the talking
+- the user is asked to share or pass only at the room's natural openings
+- if the user says something heavy, the room pauses longer before answering
+- if the user says something crisis-level, the meeting stops and turns to them
+- near the end, someone asks the hard question
+- Marcus closes the meeting, says the user's name again, and `Keep coming back` appears
+- one person catches the user with a private goodbye on the way out
+
+The room should feel relieved the user showed up, not excited to onboard them. It should feel like people in recovery, not a therapist, not a product flow, and not a dashboard.
+
+## Explicit Backend Gaps To Close
+
+These are part of the plan. They are not optional.
+
+1. `crosstalk` currently affects significance but does not select the crosstalk prompt. `hard_question` and `farewell` are missing as real persisted interaction types.
+2. Speaking order for the three rounds must be frontend-owned. The current share route hardcodes round speakers and ignores the round speaker the page needs to send.
+3. `buildGoodbyePrompt()` already exists and must be wired as a true farewell beat instead of being faked through `respond_to`.
+4. The current app has no truthful meeting-scoped participant roster. Two visitor seats are part of the target room, so the roster must be persisted and reloadable.
+
+## Progress
+
+- [x] (2026-03-19 09:35Z) Audited the current meeting page, backend share route, prompt builders, database seam, and participant roster gap; converted those findings into this ExecPlan.
+- [x] (2026-03-19 10:20Z) Phase 1 complete enough to build on: interaction types are real through the seam, meeting-scoped participants persist through the database adapter, page load bootstraps a persisted eight-person roster, and intro completion no longer shortcuts past the user gate with crude speaker counts.
+- [x] (2026-03-19 15:58Z) Phases 2 through 6 are substantially implemented: the meeting page now renders as a single-column room shell, the opening ritual auto-runs, topic selection is room-led, rounds stop only for user turns, hard question / farewell are real interaction modes, and the close lands in reflection instead of dashboard chrome.
+- [ ] (2026-03-19 16:05Z) Phase 7 is partially complete: crisis interruption now stops the room sequence and refresh restores the truthful next user gate, but replay-free recovery for every mid-beat auto sequence is still deferred pending richer persisted ritual substep state.
+
+## Surprises & Discoveries
+
+- Observation: the meeting page already auto-runs some room-led phases, but the visible UI still reads like a control panel.
+  Evidence: `app/src/routes/meeting/[id]/+page.svelte` already has room-led auto-request logic, yet still renders meeting ID, raw phase, editable meeting metadata, transcript debug details, and operational controls.
+
+- Observation: the two random visitor seats from the original experience are not just a front-end shuffle problem; they are a persistence and schema problem.
+  Evidence: `app/src/lib/core/character-selector.ts` generates visitors with synthetic `visitor-*` ids, `public.characters.id` is a UUID column, `public.meeting_participants` has no ordering column, `app/src/routes/meeting/[id]/+page.server.ts` loads only `CORE_CHARACTERS`, and `app/src/lib/server/seams/database/adapter.ts` rejects unknown character ids during share persistence.
+
+- Observation: `crosstalk` is only a significance label today, not a prompt mode, and `hard_question` / `farewell` are not first-class interaction types.
+  Evidence: `buildCrosstalkReactionPrompt()`, `buildHardQuestionPrompt()`, and `buildGoodbyePrompt()` exist in `app/src/lib/core/prompt-templates.ts`, but the share route does not branch to them and the enum unions do not include all required values.
+
+- Observation: the original React component body was not present in the user prompt; only its named functions and the canonical sequence were provided.
+  Evidence: Appendix A contained the placeholder text `[PASTE THE ORIGINAL REACT COMPONENT HERE]`.
+
+- Observation: `TOPIC_SELECTION` only had one durable server-side beat, but the experience needed both Marcus asking for the topic and Marcus acknowledging the chosen topic.
+  Evidence: `transitionToNextPhase()` advanced `topic_selection -> sharing_round_1` on any room-led share, while `buildTopicAcknowledgmentPrompt()` already existed unused in `app/src/lib/core/prompt-templates.ts`.
+
+- Observation: the meeting page can restore honest user gates from persisted phase state, but it still cannot replay every in-progress automated beat without more granular persisted sequence state.
+  Evidence: `syncInputModeFromPersistedPhase()` can show `intro`, `topic`, `share`, and `reflection` gates truthfully, but the persisted phase snapshot does not encode all intra-round steps needed to resume arbitrary mid-beat room motion.
+
+## Decision Log
+
+- Decision: treat the `Experience Target` and `Canonical Sequence Map` sections in this plan as the real source of truth, and treat the named React functions as intent anchors rather than literal code to port.
+  Rationale: the body of the original React component is absent, so the plan must not invent details and call them traceability.
+  Date/Author: 2026-03-19 / Codex
+
+- Decision: make a meeting-scoped participant roster the source of truth for who is in the room, rather than trying to fake `random1` and `random2` on the client.
+  Rationale: the current app cannot persist or reload visitor speakers cleanly without a real roster, and the schema already contains `meeting_participants`.
+  Date/Author: 2026-03-19 / Codex
+
+- Decision: add an explicit `seat_order` to `meeting_participants` and use database ids for persisted visitor rows.
+  Rationale: synthetic selector ids cannot be stored in a UUID primary key column, and intro order must survive refresh.
+  Date/Author: 2026-03-19 / Codex
+
+- Decision: keep the existing route boundaries (`/share`, `/user-share`, `/crisis`, `/close`, `/expand`) and do not add a new orchestration endpoint.
+  Rationale: the existing routes already map to the right room beats; the missing work is wiring and page orchestration, not backend proliferation.
+  Date/Author: 2026-03-19 / Codex
+
+- Decision: persist the roster and intro order, but do not persist round order. Derive round order deterministically from the meeting id plus the non-Marcus participant ids.
+  Rationale: the room needs stable intro order on refresh, different round order across meetings, and deterministic tests without a second round-order table.
+  Date/Author: 2026-03-19 / Codex
+
+- Decision: do not route all meeting logic through one giant `autoPlay()` chain. Use named, interruptible sequence functions in `+page.svelte`.
+  Rationale: crisis interrupts, heavy-share pauses, and user gates all require stop points. A monolith would be fragile and hard to debug.
+  Date/Author: 2026-03-19 / Codex
+
+- Decision: split the `topic_selection` behavior by interaction type instead of inventing a new persisted phase.
+  Rationale: the route already receives `interactionType`, `buildTopicAcknowledgmentPrompt()` already existed, and this let Marcus ask for the topic and then acknowledge the chosen topic without adding a second schema or route contract.
+  Date/Author: 2026-03-19 / Codex
+
+- Decision: stop Phase 7 short of fake “full refresh resume” claims and defer the remaining replay-free mid-beat resume problem.
+  Rationale: the current persisted phase model does not encode enough substep detail to resume every in-flight automated room beat honestly, and patching around that on the client would add debt.
+  Date/Author: 2026-03-19 / Codex
+
+## Outcomes & Retrospective
+
+- Shipped:
+  - roster-backed meeting load and stable visitor persistence
+  - real `hard_question` / `farewell` / `crosstalk` prompt routing
+  - room-led meeting page flow with opening ritual, topic chooser, three rounds, closing, ritual `Keep coming back`, and reflection
+  - crisis interruption that stops the live room sequence instead of letting queued beats continue underneath it
+  - topic-selection ask/ack split using the existing phase plus interaction-type semantics
+- Not fully shipped:
+  - replay-free resume for every possible mid-beat refresh state
+  - a fully spoken newcomer-specific welcome before the topic chooser; the current version still uses local room text for that beat
+  - cleanup of the remaining Svelte 5 rune warnings in `+page.svelte`
+- Verification actually run:
+  - targeted unit / route suites for roster persistence, share routing, adapter behavior, page load, and ritual progression
+  - targeted ESLint on the edited restore files
+  - `npm run check` with zero errors and 8 known warnings
+
+## Source Of Truth, Conflict Rules, And Divergence Budget
+
+The priority order is strict:
+
+1. `Experience Target` in this document.
+2. `Canonical Sequence Map` in this document.
+3. `Explicit Backend Gaps To Close` in this document.
+4. The current repository boundaries in `AGENTS.md`, `app/AGENTS.md`, and `app/src/AGENTS.md`.
+5. The existing code.
+
+If two requirements conflict, the winner is:
+
+- user experience beats code elegance
+- correct room timing beats micro-optimization
+- crisis correctness beats happy-path neatness
+- sequence order beats "simpler" implementation
+- existing seam boundaries beat route-level hacks
+
+Allowed divergence from the original:
+
+- Timing may vary by plus or minus 20 percent from the target delays when network latency forces it, but do not shorten intentional silences below 80 percent of the requested delay.
+- The two placeholder slots named `random1` and `random2` may be implemented as two real visitor participants with generated ids and names, as long as there are exactly two of them and they occupy those two intro/round slots.
+- Visual styling may change from the old React UI, but the room structure may not: circle at top, transcript in the middle, one bottom control at a time.
+
+Not allowed:
+
+- swapping sequence order
+- skipping the empty chair
+- turning the topic chooser into free text
+- exposing phase labels or meeting IDs to the user
+- keeping a manual "generate" control
+- using `respond_to` as a shortcut for `farewell`
+
+## Git Protocol
+
+Use branch `claude/assess-app-divergence-APpi7` unless the branch already exists with unrelated work; in that case, branch from current `main` and keep the same prefix and purpose in the branch name.
+
+The rules are not optional:
+
+- one commit per phase
+- do not begin the next phase until the current phase has passed its acceptance criterion and the worktree is clean
+- use the commit message listed inside the phase exactly, unless the executing agent adds a ticket or scope suffix for clarity
+- if a phase fails badly, revert to the immediately previous phase commit instead of patching forward blindly
+
+## Idempotence And Recovery
+
+This restore must be safe to run in pieces.
+
+- The meeting-participant bootstrap in Phase 1 must be idempotent. Reloading the meeting page must not create duplicate visitor rows or duplicate `meeting_participants` rows.
+- The page-level sequence functions in later phases must always clear pending timers and close open `EventSource` handles on unmount, crisis entry, and route change. A page that can be left and revisited safely is part of correctness, not polish.
+- Every phase ends in a single commit. Rolling back that phase means reverting only that phase's commit. If two unrelated ideas end up in the same diff, stop and split them before committing.
+
+## What I Am Not Building
+
+This plan does not authorize:
+
+- new backend routes
+- new AI providers or prompt systems
+- a modal-based crisis flow
+- a progress bar, phase badge, round badge, or other task framing
+- character bios, avatar click affordances, or a speaker picker
+- a text box for open-ended topic entry
+- a "restart meeting" or "skip intros" control
+- general prompt rewrites beyond wiring the existing missing prompt builders and the explicitly required closing-context data
+- cleanup of unrelated production, auth, deployment, or backlog issues unless they block this exact work
+
+Anything outside this scope goes into `DEFERRED.md` immediately. The user named `/home/user/The14thstep/DEFERRED.md`; in this checkout, create or update repo-root `DEFERRED.md` at `/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/DEFERRED.md` and mirror the same entry to `/home/user/The14thstep/DEFERRED.md` only if that path exists in the executing environment.
+
+## Do-Not-Touch Zones And Narrow Exceptions
+
+Do not redesign these files or move their responsibilities:
+
+- `app/src/lib/core/prompt-templates.ts`
+- `app/src/lib/core/characters.ts`
+- `app/src/lib/core/style-constitution.ts`
+- `app/src/routes/meeting/[id]/user-share/+server.ts`
+- `app/src/routes/meeting/[id]/crisis/+server.ts`
+- `app/src/routes/meeting/[id]/close/+server.ts`
+- `app/src/routes/meeting/[id]/expand/+server.ts`
+- `app/src/routes/+page.svelte`
+
+Allowed narrow exceptions:
+
+- `app/src/lib/core/types.ts` and `app/src/lib/core/meeting.ts` may be edited only to add the missing interaction-type values and any meeting-participant types required by the roster contract.
+- `app/src/lib/core/character-selector.ts` may be edited only if the existing selector needs a stable exported type or helper for the meeting roster. Do not rewrite visitor generation logic.
+- `app/src/lib/core/ritual-orchestration.ts` may be edited only if the plan cannot satisfy the canonical sequence without aligning a transition or a "requires user input" rule. Do not collapse the phase machine into page-only state.
+- `app/src/routes/meeting/[id]/share/+server.ts` may be edited only to wire the missing prompt modes, honor the frontend-owned round speaker within the roster contract, and keep phase persistence truthful.
+
+The existing route boundaries are fixed seams. Do not add a catch-all "meeting engine" endpoint just because the page orchestration feels busy. The page is allowed to orchestrate. The server routes are allowed to stay narrow.
+
+## Context And Orientation
+
+The current meeting page is not empty. It already has transcript state, SSE streaming, crisis handling, close handling, and a persisted ritual phase. The real problem is that it still behaves like a dashboard wrapped around those capabilities.
+
+The current page in `app/src/routes/meeting/[id]/+page.svelte` is running two state models at once. A local `meetingPhase` drives whether the right rail shows input or reflection. A persisted `ritualPhaseState` tracks the room phases in the database. The page also still shows meeting diagnostics, editable metadata, transcript debug data, raw status text, and operational controls. That visible scaffolding breaks the room.
+
+The backend already exposes the right route seams:
+
+- `app/src/routes/meeting/[id]/share/+server.ts` streams a character share over SSE.
+- `app/src/routes/meeting/[id]/user-share/+server.ts` persists a user share and returns `crisis` and `heavy` flags.
+- `app/src/routes/meeting/[id]/crisis/+server.ts` interrupts with crisis support.
+- `app/src/routes/meeting/[id]/close/+server.ts` closes and summarizes the meeting.
+- `app/src/routes/meeting/[id]/expand/+server.ts` expands a share on demand.
+
+The restoring work is therefore split cleanly:
+
+- Phase 1 makes the backend capable of all required beats and makes the participant roster real.
+- Later phases make the meeting page use those capabilities in the right order and with the right visible shape.
+
+The UI target is also fixed:
+
+- mobile is single-column
+- desktop may breathe more, but it must still read like one room, not a three-column dashboard
+- `MeetingCircle` stays visible through the meeting and keeps the amber active-speaker ring
+- the transcript is the center of gravity
+- the bottom region shows one control only
+
+## Canonical Sequence Map
+
+This section exists so the executing agent does not need to reconstruct the meeting from scattered phase prose.
+
+On mount:
+
+- wait 500ms
+- append the empty-chair system line
+- wait 2000ms
+- request Marcus while the meeting is in `OPENING`; do not send a special interaction type
+- wait 3000ms
+- append `— moment of silence —`
+- wait 3000ms
+- append `*Chrystal pulls out a folded paper*`
+- wait 800ms
+- request Chrystal while the meeting is in `EMPTY_CHAIR`; do not send a special interaction type
+- wait 3500ms
+- append `— introductions —`
+- wait 800ms
+
+Introductions:
+
+- request intro shares in this exact order: Marcus, Heather, Meechie, Gemini, Gypsy, Chrystal, visitor 1, visitor 2
+- optionally append `Hi [name]!` after an intro
+- append `*The room settles. Everyone is waiting.*`
+- wait 1500ms
+- show `Introduce yourself`
+
+User intro:
+
+- append `I'm [name]. I'm an addict. [cleanTime].`
+- append `Hi [name]!`
+- wait 1200ms
+- if the user is new or not currently clean, request a brief welcome from Marcus or Heather
+- wait 1500ms
+- request Marcus asking for a topic
+- show the curated topic chooser
+
+Topic selection:
+
+- user chooses one topic from the fixed list
+- request Marcus for a short acknowledgment
+- begin round 1
+
+Round 1:
+
+- request `speakingOrder[0]` full share
+- optionally request `speakingOrder[1]` as `crosstalk`
+- request `speakingOrder[1]` full share
+- show `What comes up for you?`
+
+User share 1:
+
+- post to `/user-share`
+- if crisis: enter crisis mode immediately
+- if heavy: append silence, wait 3500ms, then request a response
+- else: optional brief acknowledgment or non-verbal action
+- continue to round 2
+
+Round 2:
+
+- apply the keyword-based parallel-story swap if present
+- request the first full share
+- optional crosstalk or disagreement texture
+- request the second full share
+- request one direct-to-user prompt
+- show `How does this land?`
+
+User share 2:
+
+- post to `/user-share`
+- if there have been at least two real user shares and the hard question has not been asked, request one `hard_question`
+- continue to round 3
+
+Round 3:
+
+- request `speakingOrder[4]` full share
+- request `speakingOrder[5]` full share
+- request Marcus asking for anything final
+- show `Anything else before we close?`
+
+Closing:
+
+- optional brief Marcus acknowledgment of the user's final share
+- request Marcus closing share with confidentiality reminder and user mood context
+- wait 2000ms
+- request one more goodbye from Heather or an earlier speaker
+- wait 1500ms
+- append `— Keep coming back —`
+- request one private `farewell`
+- call `POST /close`
+- show post-meeting reflection and `New meeting`
+
+Crisis:
+
+- may interrupt any round or closing user turn
+- stops the normal sequence immediately
+- appends crisis response in the transcript, not in a modal
+- does not allow queued room beats to continue underneath
+
+## Plan Of Work
+
+The work proceeds in one direction. First make the backend truthful: real persisted participants, real interaction types, and share-route behavior that can support the room beats the page needs. Then strip the dashboard shell out of the page so the user stops operating the meeting. Then restore the meeting in order: opening ritual, intro gate, topic gate, round one, round two, round three, closing, crisis, and refresh truthfulness. Do not skip ahead to polish or visual texture before the sequence is mechanically correct.
+
+The page is the orchestrator. The server routes are the room's narrow service boundaries. The database seam is where roster truth and share truth live. The executing agent should keep that layering intact the whole time.
+
+## Interfaces And Dependencies
+
+### Meeting roster contract
+
+The meeting page must receive exactly eight participants from `app/src/routes/meeting/[id]/+page.server.ts`:
+
+- Marcus, always chair
+- Heather
+- Meechie
+- Gemini
+- Gypsy
+- Chrystal
+- two generated visitors
+
+Each participant record must include the fields the UI already uses (`id`, `name`, `avatar`, `color`, `cleanTime`, `tier`, `role`) and enough narrative fields for the share route to build the prompt if that participant speaks. The roster must be persisted per meeting so a refresh does not regenerate different visitors.
+
+Each participant record's `id` must be the persisted id returned from the database load. For visitors, that means a real UUID-backed character id, not the selector's temporary `visitor-*` placeholder. The roster must also expose `seatOrder` so intro order is stable and reloadable.
+
+### Speaking-order contract
+
+The frontend owns round order. It must build a seven-entry `speakingOrder` from the non-Marcus participants. That order must be:
+
+- deterministic within one meeting
+- different across different meetings
+- independent of intro order
+
+Intro order is not shuffled. Intro order is fixed:
+
+- `marcus`
+- `heather`
+- `meechie`
+- `gemini`
+- `gypsy`
+- `chrystal`
+- visitor 1
+- visitor 2
+
+Implement that fixed order by sorting the persisted roster on `seatOrder`, not by regenerating or guessing visitor slots on the page.
+
+### Share interaction contract
+
+Opening, reading, and introductions are phase-selected prompt families. They are not `ShareInteractionType` values.
+
+The share route must understand these persisted interaction types as distinct modes:
+
+- `standard`
+- `respond_to`
+- `disagree`
+- `parallel_story`
+- `expand`
+- `crosstalk`
+- `hard_question`
+- `farewell`
+- `callback`
+
+`crosstalk`, `hard_question`, and `farewell` are not aliases for `respond_to`. They are different tones, different lengths, and different uses.
+
+If `ritualPhaseState` and `interactionType` disagree, resolve them with this rule:
+
+- in `OPENING`, `EMPTY_CHAIR`, `INTRODUCTIONS`, and `TOPIC_SELECTION`, phase wins and `interactionType` may only be omitted or informational
+- in `SHARING_ROUND_1`, `SHARING_ROUND_2`, and `SHARING_ROUND_3`, `interactionType` may override the default share prompt for `crosstalk` and `hard_question`
+- `farewell` is only legal after the visible close has happened and before the meeting is marked post-meeting
+- if an illegal combination arrives, reject it in the route and fix the caller instead of silently guessing
+
+### Page sequence contract
+
+The page must use small interruptible async functions, not one unbroken chain. The minimum named responsibilities are:
+
+- bootstrap roster and transcript state
+- run opening ritual
+- run introductions
+- wait for user intro
+- wait for topic selection
+- run a round
+- handle a user turn
+- enter crisis mode
+- run closing
+
+Those functions may call each other, but each must be able to stop if crisis interrupts or if the component unmounts.
+
+The page must also carry an explicit cancellation token or monotonically increasing sequence id that every pending timeout and every `EventSource` callback checks before mutating state. Do not rely on "best effort cleanup" with loose booleans.
+
+### Transcript bootstrap contract
+
+The page must hydrate from persisted meeting shares when they exist. An in-progress meeting must not start from an empty transcript after refresh. `+page.server.ts` therefore has to return both the roster and the existing transcript history needed for the room to resume honestly.
+
+### Listening-only contract
+
+`listeningOnly` is an existing supported mode and must survive the restore.
+
+- the user still joins, is named, introduces themself, and chooses a topic
+- the room still runs all three rounds
+- the three user share gates are skipped automatically
+- the hard question is never asked
+- the closing still happens normally
+
+Do not remove or silently degrade listening-only just because it complicates the sequence engine.
+
+### Deterministic randomness contract
+
+Every probabilistic beat in the page layer must be deterministic for one meeting and one transcript path. That includes:
+
+- whether a `Hi [name]!` echo appears after an intro
+- whether an "almost share" beat appears
+- whether a non-verbal action line appears
+- whether crosstalk appears when it is optional
+
+Do not use `Math.random()` directly in the page. Use a seeded helper derived from `meetingId` plus a stable step key so refresh and tests remain truthful.
+
+### Deferred-work contract
+
+The first time the executing agent spots a real issue that is outside this plan, it appends one dated sentence to `DEFERRED.md` and then returns to the plan. Do not "just fix one more thing."
+
+## Curated Topic List
+
+Use these exact topics. Do not paraphrase them, add extra ones, or replace them with free text:
+
+- `Staying clean when everything falls apart`
+- `People who don't understand what we've been through`
+- `Trusting yourself again`
+- `The difference between being alone and being lonely`
+- `When the people closest to you don't believe you've changed`
+- `Dealing with the things you did`
+- `Finding reasons to stay`
+- `Coming back after relapse`
+- `The people we lost`
+- `When staying clean feels harder than using`
+
+## Voice Audit Anchors
+
+Use these to audit generated text. They are not prompt additions. They are quality checks.
+
+Marcus:
+
+- Correct: "Now let me own my side before I tell on anybody else."
+- Incorrect: "I invite everyone to explore the emotions this topic brings up tonight."
+
+Heather:
+
+- Correct: "Listen, I did not survive all that to die embarrassed."
+- Incorrect: "Let's all hold compassionate space for each other right now."
+
+Meechie:
+
+- Correct: "Relapse starts for me when I call isolation peace."
+- Incorrect: "I'm feeling vulnerable but optimistic about my healing journey."
+
+Gemini:
+
+- Correct: "I wanted to run, no, I wanted somebody to stop me."
+- Incorrect: "I finally have total clarity and no contradiction left in me."
+
+Gypsy:
+
+- Correct: "Phoenix taught me heat and loneliness are cousins."
+- Incorrect: "Recovery is a beautiful journey of self-discovery."
+
+Chrystal:
+
+- Correct: "March 3 was the day I handed over my old phone and numbers."
+- Incorrect: "Growth looks different for everyone, and that's okay."
+
+If a generated line sounds more like the incorrect example than the correct one, it fails, even if the tests pass.
+
+## Anti-Pattern Manifest
+
+Every item below is a known trap. The executing agent must be able to point to the phase that prevents it before proceeding.
+
+1. Replacing silence with a spinner. Wrong because silence is part of the room; a spinner is infrastructure.
+2. Keeping or reintroducing a manual `Generate Character Share` control. Wrong because it makes the user the operator.
+3. Showing progress bars, round badges, or phase pills. Wrong because the room is not a task.
+4. Making the empty chair skippable. Wrong because ritual is part of the room.
+5. Flattening the rounds into one endless AI chat stream. Wrong because meetings need shape.
+6. Handling crisis in a modal while the feed continues underneath. Wrong because the room stops.
+7. Letting the user choose the next speaker. Wrong because people are not menu items.
+8. Replacing the curated topic list with a free-text topic box. Wrong because the list teaches the room's language.
+9. Adding a skip-intros control. Wrong because every meeting starts with introductions.
+10. Auto-expanding every share. Wrong because "Tell me more" is a deliberate act.
+11. Using emojis or glossy icons for action lines. Wrong because `*shifts in seat*` belongs to the room's register.
+12. Adding character bio popups. Wrong because people should be learned through what they say.
+13. Building one giant `autoPlay()` chain. Wrong because crisis, heavy silence, and user gates require interruption points.
+14. Showing the meeting phase to the user. Wrong because the phase machine is backstage machinery.
+15. Using skeleton loaders for speaker turns. Wrong because a person thinking is not a skeleton.
+16. Debouncing or thinning intentional pauses to "optimize." Wrong because the timing is content.
+17. Adding a restart button during the meeting. Wrong because the room should not teach exit-at-discomfort.
+18. Rendering raw operational status text like `Share saved` or `Streaming:`. Wrong because it breaks the room.
+19. Collapsing intake into one form page. Wrong because intake is slow attention, not sign-up friction.
+20. Porting the old React client logic directly and bypassing the SvelteKit routes. Wrong because the backend already exists and must remain the source of persistence and crisis state.
+21. Faking `random1` and `random2` in the page without a real meeting roster. Wrong because refresh and persistence will immediately lie.
+22. Using `respond_to` as the private farewell. Wrong because the goodbye builder already exists and should own that tone.
+23. Leaving transcript debug metadata visible in `ShareMessage.svelte`. Wrong because significance scores and sequence numbers are operator data, not room data.
+24. Letting local UI state diverge from persisted `ritualPhaseState` without an explicit bridge. Wrong because the room will replay or skip beats on refresh.
+
+## Phase 1 — Make The Backend Capable Of A Real Room
+
+Starting state: the app can stream and persist shares, but the missing prompt modes are unwired, round speakers are not frontend-owned, and there is no real meeting-scoped participant roster for visitors.
+
+Objective: make the backend routes and database seam capable of every meeting beat the page needs, without adding a new endpoint or changing the core voice system.
+
+Files to change:
+
+- `app/src/lib/core/types.ts`
+- `app/src/lib/core/meeting.ts`
+- `app/src/lib/seams/database/contract.ts`
+- `app/src/lib/seams/database/contract.test.ts`
+- `app/src/lib/seams/database/fixtures/appendShare.sample.json`
+- `app/src/lib/seams/database/mock.ts`
+- `app/src/lib/server/seams/database/adapter.ts`
+- `app/src/lib/server/seams/database/adapter.spec.ts`
+- `app/supabase/migrations/20260319_000003_restore_meeting_roster_and_share_interactions.sql`
+- `app/src/routes/meeting/[id]/share/+server.ts`
+- `app/src/routes/meeting/[id]/+page.server.ts`
+- `app/src/lib/core/prompt-templates.spec.ts`
+- `app/src/lib/server/routes/meeting-page-load.spec.ts`
+- `app/src/lib/server/routes/meeting-share.spec.ts`
+- `app/src/lib/server/routes/meeting-ritual-phase.integration.spec.ts`
+
+What to do:
+
+1. Add `hard_question` and `farewell` to `ShareInteractionType` in both `app/src/lib/core/types.ts` and `app/src/lib/core/meeting.ts`. Keep `crosstalk` in place. Do not change the meaning of existing interaction values.
+2. Add `interactionType` to the database seam's `ShareRecord` contract, fixture, mock, and adapter mapping. The restore cannot truthfully persist `hard_question`, `farewell`, or `crosstalk` while the seam still records every share as `standard`.
+3. Add a meeting-participant type to `app/src/lib/core/types.ts` that represents one persisted room participant. It must carry the existing character profile fields the UI already needs plus `role`, `isVisitor`, and `seatOrder`.
+4. Add one migration that does both of the required persistence repairs:
+   - expand the `shares.interaction_type` check constraint to allow `hard_question` and `farewell`
+   - add `seat_order integer not null` to `meeting_participants` and enforce uniqueness of `(meeting_id, seat_order)`
+5. Extend the database seam contract with two roster operations:
+   - one to save the meeting's selected participants exactly once and return the persisted roster with final ids
+   - one to load the meeting's selected participants on demand in `seat_order`
+   Implement the contract, mock, and adapter in Seam-Driven Development order. Use the existing `public.meeting_participants` table plus `public.characters`. Do not add a new table.
+6. In the database adapter, when saving participants for a meeting:
+   - preserve core characters by reusing their existing db mappings
+   - insert real visitor rows into `public.characters` and let the database assign UUIDs
+   - insert `meeting_participants` rows for all eight room members with stable `seat_order`
+   - return the persisted roster with final ids so the page never has to trust the selector's temporary visitor ids
+   - make the whole operation idempotent so reload or retry does not duplicate participants
+7. In `app/src/routes/meeting/[id]/+page.server.ts`, load the meeting participants and the existing transcript history. If the meeting does not yet have any participants, call the existing selector once, persist the roster through the new seam method, then load and return that roster to the page. Do not regenerate visitors on every page load.
+8. In `app/src/routes/meeting/[id]/share/+server.ts`, import and wire the three existing prompt builders:
+   - `buildCrosstalkReactionPrompt()`
+   - `buildHardQuestionPrompt()`
+   - `buildGoodbyePrompt()`
+   Branch on `interactionType` before falling back to the standard share prompt. Do not introduce `opening`, `reading`, or `intro` as interaction-type enum values; those remain phase-selected prompt families.
+9. Change the share route's speaker selection rule:
+   - during `OPENING`, `EMPTY_CHAIR`, `INTRODUCTIONS`, and `TOPIC_SELECTION`, phase wins and the route enforces the phase speaker
+   - during sharing rounds, if the page provides a `characterId` that belongs to the meeting's persisted roster, honor it
+   - during the post-close private goodbye beat, allow `interactionType=farewell` to override the default closing prompt
+   - Marcus remains outside the shuffled speaking order and should only be used when the sequence explicitly calls for Marcus
+10. Keep the route's persisted `phaseState` truthful. Do not hide phase progression in page-only state.
+11. Add tests that prove:
+   - page load returns eight persisted participants, including exactly two visitors, sorted by `seat_order`
+   - reloading a meeting returns the same roster, the same visitor ids, and existing transcript history
+   - `interactionType=crosstalk` uses the crosstalk prompt
+   - `interactionType=hard_question` uses the hard-question prompt
+   - `interactionType=farewell` uses the goodbye prompt
+   - opening, reading, and intro beats still come from phase selection rather than illegal interaction-type values
+   - round shares honor a valid frontend-provided speaker from the meeting roster
+
+What NOT to do:
+
+- Do not store the visitor roster inside `phaseState`. The reason is that `phaseState` is for progress through the ritual, not for reconstructing room membership on refresh.
+- Do not pretend the selector's temporary visitor ids are database ids. The reason is that `public.characters.id` is UUID-backed and the page must switch to persisted ids after bootstrap.
+- Do not keep server-owned hardcoded round arrays for sharing rounds. The reason is that the user explicitly wants frontend-owned round order, and hardcoding the rounds would keep the old drift alive under new UI.
+- Do not invent a new `/participants` endpoint. The reason is that page load already owns bootstrap, and adding another route would add architecture without adding capability.
+- Do not "solve" farewell by reusing `respond_to`. The reason is that a room goodbye is shorter and more direct than a conversational response, and the correct builder already exists.
+
+Acceptance criterion:
+
+From `app/`, run:
+
+    npm run test:unit -- --run src/lib/server/routes/meeting-page-load.spec.ts src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-ritual-phase.integration.spec.ts src/lib/core/prompt-templates.spec.ts
+
+The named specs for persisted participant loading, transcript bootstrap, prompt branching, persisted interaction-type storage, and frontend-owned round speakers pass. A development log or targeted test assertion proves that `hard_question` and `farewell` do not reuse the standard response prompt, and that opening/reading/introduction calls are not rejected as invalid interaction types.
+
+This phase satisfies the `Experience Target` precondition that the room contains two real additional people and can later ask the hard question and say goodbye in the right voices.
+
+Experience note:
+
+At the end of this phase, the room still looks wrong, but the backend stops lying. There is now a real room to orchestrate instead of six hardcoded core speakers pretending to be a meeting.
+
+Emotional intent tag: PRESENCE
+
+Git commit message:
+
+`fix(meeting): persist room roster and real interaction types — frontend can now run a truthful meeting`
+
+Self-critique checkpoint:
+
+Compare this phase against `Experience Target` and `Explicit Backend Gaps To Close` in this document. If the route still cannot produce a real crosstalk line, a real hard question, a real farewell, or two real persisted visitors, this phase is not done.
+
+Experience audit:
+
+The user should not feel this phase yet, and that is fine. What changes here is honesty: the room now has actual people in it, and the route can speak in the right tones later. If a refresh would still swap out the visitors, the phase failed.
+
+## Phase 2 — Strip The Dashboard Out Of The Room
+
+Starting state: the page has the right raw capabilities but still exposes operator chrome, debug metadata, and multiple competing controls.
+
+Objective: make the meeting page look and behave like one room with one active bottom control, while preserving the existing route boundaries.
+
+Files to change:
+
+- `app/src/routes/meeting/[id]/+page.svelte`
+- `app/src/lib/components/MeetingCircle.svelte`
+- `app/src/lib/components/ShareMessage.svelte`
+- `app/src/lib/components/SystemMessage.svelte`
+- `app/src/lib/components/UserInput.svelte`
+- `app/src/lib/components/MeetingReflection.svelte`
+- `app/src/lib/core/meeting-speaking-order.ts`
+- `app/src/lib/core/meeting-speaking-order.spec.ts`
+- `app/src/lib/server/routes/meeting-page-load.spec.ts`
+- `tests/e2e/meeting-flow.spec.ts`
+
+What to do:
+
+1. Create a pure helper in `app/src/lib/core/meeting-speaking-order.ts` that takes the meeting id and the non-Marcus participant ids and returns:
+   - a deterministic shuffled `speakingOrder`
+   - deterministic yes/no decisions for optional room texture beats keyed by step name
+   The same meeting id and roster must yield the same outputs. Different meetings must usually yield different outputs. Do not use `Math.random()` in the page after this helper exists.
+2. In `app/src/routes/meeting/[id]/+page.svelte`, remove the visible admin shell by name:
+   - meeting ID display
+   - phase pill
+   - editable topic input
+   - editable name input
+   - editable mood input
+   - `Close Meeting` toolbar button
+   - raw operational status text
+   - any visible `Generate Character Share` control, even as a hidden fallback
+3. Rebuild the page around three vertical regions:
+   - top: `MeetingCircle`
+   - middle: transcript
+   - bottom: exactly one active user-facing control area
+   Keep the page single-column on mobile. On desktop, keep the visual reading order top-to-bottom even if margins widen.
+4. Treat the bottom area as an explicit gate renderer. It may show only one of these at a time:
+   - nothing while the room is auto-playing
+   - the `Introduce yourself` button
+   - the topic chooser
+   - the share/pass input for a user turn
+   - the post-meeting reflection controls
+5. Keep `ShareMessage`, `SystemMessage`, `UserInput`, and `MeetingReflection`, but remove their room-breaking affordances:
+   - `ShareMessage` must stop showing significance score or sequence number
+   - `SystemMessage` must be used for room-native action lines and ritual text, not raw transport status
+   - `UserInput` must accept prompt/label/button text from the page so it can say `What comes up for you?`, `How does this land?`, and `Anything else before we close?`
+   - `MeetingReflection` must read like an end state, not a return-to-dashboard card
+   - `MeetingCircle` must keep the amber active-speaker ring but stop reading like a debug/status widget
+6. Replace raw streaming status with an in-room thinking indicator. Use the existing three-dot idea if present; do not use a skeleton or a spinner.
+7. Seed the local transcript state from the shares returned by `+page.server.ts` instead of starting from an empty array. A refresh into an in-progress meeting must show what has already happened.
+8. Make the page's visible state derive from the persisted `ritualPhaseState` plus a small local gate enum. The local state may control what bottom control is shown, but it must never contradict the ritual phase.
+9. Add or update Playwright coverage so the page fails if the old dashboard elements reappear.
+
+What NOT to do:
+
+- Do not leave hidden debug metadata in the DOM because "only developers will notice." The reason is that hidden fallback controls and debug text tend to leak back into the room later.
+- Do not make the page prettier by adding generic product polish like cards, badges, or progress UI. The reason is that the goal is not "more polished app chrome"; it is less visible app chrome.
+- Do not let `UserInput.svelte` hardcode `Your Share` and `Submit Share`. The reason is that each user gate has a different role in the meeting.
+- Do not create a new generalized room-layout system. The reason is that the restore only needs one immersive meeting page, not a design-system detour.
+
+Acceptance criterion:
+
+Run the meeting page locally and inspect the DOM or the Playwright assertion. The following strings and controls are absent: `Meeting ID`, raw phase label, topic/name/mood edit fields, `Generate Character Share`, `Close Meeting`, significance score, sequence number, `Streaming:`. The page shows one vertical room layout with one bottom control region.
+
+This phase satisfies the `Experience Target` beat that the UI should look and feel like a room, not a dashboard.
+
+Experience note:
+
+At this stage, the user finally stops feeling like they are in an admin panel. They still may not have the full room ritual yet, but the page no longer asks them to operate the meeting.
+
+Emotional intent tag: PRESENCE
+
+Git commit message:
+
+`fix(meeting): remove dashboard chrome from meeting page — room shell can carry the sequence`
+
+Self-critique checkpoint:
+
+If there is any visible affordance that tells the user they are looking at a state machine, a debugging surface, or a workflow tool, this phase failed. Re-open the page and look for anything that feels like an operator console.
+
+Experience audit:
+
+The room should now feel quieter before anyone speaks. The screen should stop competing with the transcript. If the user can still tell what phase the machine is in without listening to the room, the page is still wrong.
+
+## Phase 3 — Run The Opening Ritual And The Intro Gate
+
+Starting state: the room shell exists, the backend can speak the right prompt modes, and the page has a real roster and seeded round order.
+
+Objective: make the meeting start itself, carry the opening ritual, introduce everyone in the right order, and stop only at the user's introduction.
+
+Files to change:
+
+- `app/src/routes/meeting/[id]/+page.svelte`
+- `app/src/lib/server/routes/meeting-ritual-phase.integration.spec.ts`
+- `tests/e2e/meeting-flow.spec.ts`
+- `tests/composition/meeting-flow.spec.ts`
+
+What to do:
+
+1. In `+page.svelte`, implement named interruptible sequence functions for:
+   - adding a system or action line
+   - waiting an intentional delay
+   - requesting one character share over SSE
+   - running the opening ritual
+   - running the intro loop
+2. On component mount, if the persisted phase is still at or before `OPENING`, run this exact order:
+   - wait 500ms
+   - append the empty-chair system line
+   - wait 2000ms
+   - request Marcus while the persisted phase is `OPENING`; do not send a custom interaction type here
+   - wait 3000ms
+   - append `— moment of silence —`
+   - wait 3000ms
+   - append `*Chrystal pulls out a folded paper*`
+   - wait 800ms
+   - request Chrystal while the persisted phase is `EMPTY_CHAIR`; do not send a custom interaction type here
+   - wait 3500ms
+   - append `— introductions —`
+   - wait 800ms
+3. Run the introductions in exact order:
+   - Marcus
+   - Heather
+   - Meechie
+   - Gemini
+   - Gypsy
+   - Chrystal
+   - visitor 1
+   - visitor 2
+   After each intro, optionally append `Hi [name]!` using the deterministic helper from Phase 2, not raw randomness.
+4. After all eight intros, append `*The room settles. Everyone is waiting.*`, wait 1500ms, and then show exactly one bottom control: `Introduce yourself`.
+5. Make the intro button append the canonical user intro:
+   - `I'm [name]. I'm an addict. [cleanTime].`
+   Then append `Hi [name]!`, wait 1200ms, and if the user is new or not currently clean, request a brief welcome from Marcus or Heather with `interactionType=respond_to`.
+6. If `listeningOnly` is true, still show the intro button and still require the user intro. Listening-only skips share gates later; it does not skip entry into the room.
+7. After the user intro sequence, wait 1500ms and request Marcus to ask for the topic with `interactionType=respond_to`. When his share finishes, show the topic chooser and nothing else.
+8. Make every step interruptible. If crisis is entered, close any live `EventSource`, clear pending timeouts, and stop advancing the sequence.
+9. Only run opening beats that are still missing. On refresh, do not replay finished intro steps if the meeting has already advanced beyond them.
+
+What NOT to do:
+
+- Do not collapse the whole ritual into one `startMeeting()` promise chain. The reason is that the room must be able to stop for crisis, refresh, or a persisted midpoint.
+- Do not show a spinner during the silences. The reason is that silence is content here, not a waiting-room for content.
+- Do not reorder the intros just because a seeded shuffle already exists. The reason is that intro order is canonical and not part of round variety.
+- Do not treat the user intro as a text area. The reason is that this first step is ritual, not composition.
+
+Acceptance criterion:
+
+Run the deterministic meeting flow test or Playwright spec for the opening stage. From a fresh meeting, the transcript shows, in order, the empty-chair line, Marcus's opening share, the moment-of-silence line, the Chrystal paper action, Chrystal's reading, the introductions header, eight intros in canonical order, the settling line, and then the `Introduce yourself` button. No topic chooser appears before the intro button is clicked.
+
+This phase satisfies the `Experience Target` beat where the room starts itself, Marcus speaks first, silence lands, Chrystal reads, and the room waits before asking anything of the user.
+
+Experience note:
+
+This is the first phase where the room should actually feel like a room. The user joins and the meeting is already happening. The silence after Marcus has to read as the room settling, not the app buffering.
+
+Emotional intent tag: SILENCE
+
+Git commit message:
+
+`fix(meeting): autoplay opening ritual and intro gate — room starts itself before asking for the user`
+
+Self-critique checkpoint:
+
+Read the transcript top to bottom. If anything in the opening sequence feels like the computer reporting progress instead of the room moving, stop and fix it before going on.
+
+Experience audit:
+
+The user should now be able to click `Join Meeting` and then do nothing. Marcus speaks first, not the UI. The room pauses before it asks anything of the user.
+
+## Phase 4 — Make Topic Selection And Round One Feel Like A Meeting
+
+Starting state: the room starts itself, introduces everyone, and stops at the user's intro and topic choice.
+
+Objective: let the room ask for a topic, run the first round automatically, and stop at the user's first real share or pass.
+
+Files to change:
+
+- `app/src/routes/meeting/[id]/+page.svelte`
+- `app/src/lib/components/UserInput.svelte`
+- `app/src/lib/server/routes/meeting-user-share.spec.ts`
+- `tests/e2e/meeting-flow.spec.ts`
+- `tests/composition/meeting-flow.spec.ts`
+
+What to do:
+
+1. Render the exact curated topic list in the bottom control region after Marcus asks what the user wants to talk about. Do not render a text box. Render the list as one-choice buttons or radios with a clear confirm action.
+2. On topic selection:
+   - store the chosen topic in page state
+   - request Marcus with `interactionType=respond_to` for the brief acknowledgment
+   - move directly into round 1
+3. Use `speakingOrder[0]` and `speakingOrder[1]` for round 1. Request the first speaker with `interactionType=respond_to`.
+4. Use the deterministic helper from Phase 2 for every optional beat in this round:
+   - around 20 percent chance of `*[name] starts to say something, stops.*` before a share
+   - around 30 percent chance of a non-verbal action line between shares
+   - around 40 percent chance of crosstalk before the second full share
+   These probabilities are design targets. The actual decision must be seeded, not random.
+5. Keep non-verbal action lines in the page and out of the backend. Use a short curated per-character list such as `*Meechie nods*` or `*Gypsy shifts in her chair*`.
+6. If crosstalk is selected, request the second participant with `interactionType=crosstalk`, then request that same participant's full `respond_to` share. Otherwise skip straight to the second participant's `respond_to` share.
+7. If `listeningOnly` is false, show `UserInput` with the prompt `What comes up for you?`, a primary button labeled `Share`, and a secondary `Pass`.
+8. If `listeningOnly` is true, skip the share gate entirely and proceed directly into the next round after the room's final beat for this round lands.
+9. When the user does share or pass, post to `/user-share`. If the response returns `crisis: true`, enter crisis mode immediately. If it returns `heavy: true`, append `*silence in the room*`, wait 3500ms, then request Marcus or Heather with `interactionType=respond_to`. If neither flag is set, optionally append a brief one-line acknowledgment or non-verbal action and proceed.
+
+What NOT to do:
+
+- Do not let the user type a custom topic. The reason is that the topic list is part of the room's language and framing.
+- Do not fire round 1 and the user prompt simultaneously. The reason is that the user should feel asked, not interrupted by available controls.
+- Do not call `crosstalk` as a full share. The reason is that it is meant to be a brief reaction, not a second main turn.
+- Do not reduce the heavy-share pause back to the normal beat. The reason is that the room needs to let heavy disclosures land.
+
+Acceptance criterion:
+
+From a fresh meeting, advance through intro and topic selection, choose one topic, and observe this exact behavior: Marcus briefly acknowledges the topic, two automated character turns happen before the user can type, and then the only bottom control becomes a share/pass composer labeled `What comes up for you?`. If the test uses a forced heavy response fixture, the pause before the room answers is 3500ms instead of the default pause.
+
+This phase satisfies the `Experience Target` beat where the user chooses a topic and the room carries it before turning back to them.
+
+Experience note:
+
+This is where the meeting stops being ceremony and becomes conversation. The user should feel like the room picked up the topic and carried it for a while before turning back to them.
+
+Emotional intent tag: WEIGHT
+
+Git commit message:
+
+`fix(meeting): restore topic gate and round one — room speaks before first user share`
+
+Self-critique checkpoint:
+
+Ask one blunt question: did the room carry the topic, or did the user pick a topic and immediately get a blank text area? If the answer is the second one, the round still feels like a chatbot.
+
+Experience audit:
+
+The room should now sound like people responding to a topic, not like a tool waiting for user content. The user's first text area appears only after the room has shown its shape. If round one feels rushed, the phase is not done.
+
+## Phase 5 — Make Round Two Cut Deeper
+
+Starting state: the room can run the first round and collect the user's first real share or pass.
+
+Objective: implement the middle of the meeting: parallel-story swap, crosstalk/disagreement texture, the second user gate, and the hard question.
+
+Files to change:
+
+- `app/src/routes/meeting/[id]/+page.svelte`
+- `app/src/routes/meeting/[id]/share/+server.ts`
+- `app/src/lib/core/parallel-story.ts`
+- `app/src/lib/core/parallel-story.spec.ts`
+- `app/src/lib/server/routes/meeting-share.spec.ts`
+- `app/src/lib/server/routes/meeting-user-share.spec.ts`
+- `tests/e2e/meeting-flow.spec.ts`
+- `tests/composition/meeting-flow.spec.ts`
+
+What to do:
+
+1. Track the user's real submitted shares separately from passes. The hard question must not unlock from passes.
+2. Add a pure helper in `app/src/lib/core/parallel-story.ts` that maps user-share text to the optional round-two swap:
+   - custody, kid, daughter -> Marcus
+   - prison, jail, locked up -> Heather
+   - relapse, slipped, slip -> Gemini
+   - running, city, moved -> Gypsy
+   The helper returns either a character id or `null`. The page calls it after user share 1 and before choosing round-two speakers.
+3. Run round 2:
+   - first speaker full `respond_to`
+   - optional disagree/crosstalk texture from the second speaker if it fits
+   - second speaker full `respond_to`
+   - then request one direct-to-user prompt from a deterministic choice among the first four round speakers using `interactionType=respond_to`
+4. If `listeningOnly` is false, show `UserInput` with the prompt `How does this land?`
+5. If `listeningOnly` is true, skip the second user gate and continue straight to round 3.
+6. After the second user share or pass, if the user has at least two real shares, `listeningOnly` is false, and the hard question has not yet been asked, request Marcus or Meechie with `interactionType=hard_question`. Record that it was asked so it does not repeat.
+7. Preserve heavy-share silence rules here too. If the user's second share is marked `heavy`, give it the same extended pause before the room responds.
+8. Keep the meeting interruptible for crisis at every user post.
+
+What NOT to do:
+
+- Do not bury the parallel-story detection inside the page as ad hoc string matching. The reason is that the existing product direction already treats it as a pure domain rule, and it needs unit tests of its own.
+- Do not ask the hard question after only one real user share. The reason is that it should feel earned, not scripted.
+- Do not make the hard question long. The reason is that the function is to cut through, not to deliver another speech.
+- Do not let crosstalk become sarcasm for its own sake. The reason is that it should feel like room texture, not character gimmickry.
+
+Acceptance criterion:
+
+Run the round-two flow with a deterministic fixture or seeded test. When the user's first share contains a parallel-story keyword, the mapped character takes the first round-two slot. After the second real user share, exactly one hard question appears, and it is generated through `interactionType=hard_question`, not `respond_to`.
+
+This phase satisfies the `Experience Target` beat where the meeting gets more specific and someone asks the question that cuts through.
+
+Experience note:
+
+Round two is where the meeting starts to know what it is talking about. This is also where the room should begin to feel sharper and more personal without turning therapeutic or polished.
+
+Emotional intent tag: TENSION
+
+Git commit message:
+
+`fix(meeting): restore round two depth — parallel stories and hard question now land`
+
+Self-critique checkpoint:
+
+If round two feels like round one again with different speakers, it failed. The middle of the meeting should turn the room toward the user a little harder and a little more specifically.
+
+Experience audit:
+
+The room should now feel more dangerous in a good way. Someone should finally ask the user something that gets under the first answer. If the hard question feels like a generic check-in, the phase is not done.
+
+## Phase 6 — Close The Meeting Like A Meeting
+
+Starting state: the room can open, run two rounds, and ask the hard question.
+
+Objective: run the final round, gather the user's last word, close the meeting in the right tone, and leave one private line after `Keep coming back`.
+
+Files to change:
+
+- `app/src/routes/meeting/[id]/+page.svelte`
+- `app/src/routes/meeting/[id]/share/+server.ts`
+- `app/src/lib/components/MeetingReflection.svelte`
+- `app/src/lib/server/routes/meeting-close.spec.ts`
+- `app/src/lib/server/routes/meeting-share.spec.ts`
+- `tests/e2e/meeting-flow.spec.ts`
+- `tests/composition/meeting-flow.spec.ts`
+
+What to do:
+
+1. Run round 3 using `speakingOrder[4]` and `speakingOrder[5]` as full `respond_to` shares.
+2. If `listeningOnly` is false, after those two shares request Marcus with `interactionType=respond_to` to ask if the user has anything final, then show `UserInput` with the prompt `Anything else before we close?`
+3. If `listeningOnly` is true, skip the final user gate and go straight to the closing beat once round 3 lands.
+4. On final submit or pass, or immediately after round 3 in listening-only mode:
+   - if the user shared, optionally request a brief Marcus acknowledgment of that final share
+   - request Marcus's closing share with the confidentiality reminder and the user's mood included in the context
+   - wait 2000ms
+   - request Heather or `speakingOrder[0]` for a direct goodbye if it fits the room
+   - wait 1500ms
+   - append `— Keep coming back —` as a highlighted amber system line
+5. After `Keep coming back`, request one private farewell using `interactionType=farewell`. The speaker is:
+   - the character who most recently addressed the user directly, if tracked
+   - otherwise a random non-Marcus participant
+6. After the `Keep coming back` line is visible, call `POST /close` exactly once to persist the meeting summary. Do not call `/close` earlier.
+7. Replace the bottom control with the post-meeting end state:
+   - summary/reflection view
+   - `New meeting` button
+   - if `MeetingReflection.svelte` currently says `Return to Meeting`, rename or remove that control so the meeting actually ends
+
+What NOT to do:
+
+- Do not let Marcus's closing turn become a summary paragraph about the user's growth. The reason is that a meeting close should sound like a close, not a session note.
+- Do not call `/close` before the visible close has happened. The reason is that persistence should follow the room, not lead it.
+- Do not use `respond_to` for the private farewell. The reason is that the goodbye has its own tone and length, and the builder already exists.
+- Do not omit `Keep coming back`. The reason is that the meeting is not done without it.
+
+Acceptance criterion:
+
+Advance a meeting through round 3. After the final user share or pass, the transcript ends with Marcus's close, one more goodbye, `— Keep coming back —`, then a short direct farewell addressed to the user by name. The page calls `/close` once and then shows the post-meeting reflection state with a `New meeting` action.
+
+This phase satisfies the `Experience Target` beat where Marcus closes the room, says the user's name again, and the meeting ends with `Keep coming back`.
+
+Experience note:
+
+The close should feel like the room loosening, not the app completing. The last private line after `Keep coming back` should feel like someone catching the user on the way out, not a canned outro.
+
+Emotional intent tag: WARMTH
+
+Git commit message:
+
+`fix(meeting): restore closing ritual and farewell — meeting ends like a room, not a workflow`
+
+Self-critique checkpoint:
+
+Read only the last ten transcript items. If they sound like an app wrapping up work instead of a room closing down, this phase failed.
+
+Experience audit:
+
+The user should feel a little seen on the way out, not congratulated. The room should still feel like it existed before them and will exist after them. If the close sounds like support-product copy, back up and fix it.
+
+## Phase 7 — Make Crisis And Refresh Truthful, Then Run The Final Smell Test
+
+Starting state: the happy path is restored, but the restore is not complete until interruption and refresh behavior are honest.
+
+Objective: make crisis stop the meeting cold, make refresh resume the real room without replaying beats, and verify the final result against the user's smell test.
+
+Files to change:
+
+- `app/src/routes/meeting/[id]/+page.svelte`
+- `app/src/lib/server/routes/meeting-crisis.spec.ts`
+- `app/src/lib/server/routes/meeting-user-share.spec.ts`
+- `app/src/lib/server/routes/meeting-page-load.spec.ts`
+- `tests/e2e/meeting-flow.spec.ts`
+- `DEFERRED.md`
+
+What to do:
+
+1. Make crisis entry cancel the current room sequence immediately:
+   - close any active `EventSource`
+   - clear pending delays/timeouts
+   - prevent any queued round step or closing step from firing afterward
+2. Keep crisis in the transcript, not in a modal. The room stops and the crisis response appears in the same feed.
+3. Preserve `preCrisisPhase` so the room can recover honestly if the existing backend supports it, but do not auto-resume the room while the crisis response is still on screen.
+4. Make page reload bootstrap from persisted truth:
+   - load the roster from the database
+   - load existing shares
+   - derive the deterministic `speakingOrder`
+   - inspect `phaseState`
+   - show only the next valid user gate for that phase
+   - do not replay opening beats that already happened
+5. Run the smell test inventory literally. If any item is still true, do not declare done.
+6. Anything discovered here that is real but outside scope gets one dated line in `DEFERRED.md`. Do not fix it inside this phase unless it blocks the restore.
+
+What NOT to do:
+
+- Do not keep the meeting running "under" crisis. The reason is that the room turns toward the person in crisis and nothing else matters for that moment.
+- Do not paper over refresh bugs by storing transcript-only state in `sessionStorage`. The reason is that the meeting already has a real backend and should resume from persisted truth.
+- Do not silently skip smell-test failures because the end-to-end test passes. The reason is that this task is about the room feeling truthful, not merely about the code completing a loop.
+- Do not turn deferred items into opportunistic scope creep. The reason is that the restore will stall and blur if this phase starts fixing adjacent ideas.
+
+Acceptance criterion:
+
+Two checks both pass:
+
+1. Crisis check: submit a crisis-text user share during a round and observe that the normal room sequence stops, crisis shares appear inline, and no further scheduled speaker turn fires afterward.
+2. Refresh check: refresh the page during an in-progress meeting after the opening ritual and confirm that the page shows the same roster, the same transcript history, and the correct next gate without replaying the empty chair or the intros.
+
+This phase satisfies the `Experience Target` final promise that the meeting is a room that holds shape, not a brittle interface that starts over whenever something goes wrong.
+
+Experience note:
+
+This phase is where the room earns trust. When it breaks for crisis, it breaks the way a meeting would. When it resumes after a refresh, it does not pretend the earlier beats never happened.
+
+Emotional intent tag: WEIGHT
+
+Git commit message:
+
+`fix(meeting): make crisis and refresh truthful — restored room now survives interruption`
+
+Self-critique checkpoint:
+
+If a person in crisis would still see the rest of the meeting trying to continue around them, stop. That is not a bug fix left for later. That is a failed restore.
+
+Experience audit:
+
+The room should now feel dependable. It should hold shape when the user disappears and comes back. If refresh or crisis reveals the machinery again, the job is not finished.
+
+## Concrete Steps
+
+Run these from `/mnt/c/users/latro/downloads/t/recoverymeeting-autonomous-run/app` unless a step says otherwise.
+
+1. Create or switch to the branch from the Git Protocol section.
+2. Before Phase 1, capture a baseline by running:
+
+       npm run check
+       npm run test:unit -- --run src/lib/server/routes/meeting-page-load.spec.ts src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-user-share.spec.ts src/lib/server/routes/meeting-close.spec.ts src/lib/server/routes/meeting-crisis.spec.ts
+
+   Record the failing or missing behaviors in this ExecPlan before editing anything.
+3. Execute one phase at a time. After each phase:
+   - run the phase's acceptance checks
+   - commit exactly once with the listed commit message
+   - update `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective`
+4. If a phase discovers out-of-scope work, append one dated line to `DEFERRED.md` immediately and keep moving.
+5. If a phase requires a new migration, apply it locally before running page-load or route tests so the persisted behavior being tested matches the plan.
+
+## Validation And Acceptance
+
+Run these from `app/` as the work progresses:
+
+1. After Phase 1:
+
+       npm run test:unit -- --run src/lib/server/routes/meeting-page-load.spec.ts src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-ritual-phase.integration.spec.ts src/lib/core/prompt-templates.spec.ts
+
+2. After Phases 2 through 6:
+
+       npm run check
+       npm run test:unit -- --run src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-user-share.spec.ts src/lib/server/routes/meeting-close.spec.ts src/lib/server/routes/meeting-crisis.spec.ts src/lib/server/routes/meeting-page-load.spec.ts
+
+3. During UI restore work:
+
+       npm run test:e2e -- tests/e2e/meeting-flow.spec.ts
+
+   If the script does not accept a path filter, run the repo's Playwright command for that file directly and record the exact command you used in this plan.
+
+4. Final human acceptance:
+
+   - start the app with `npm run dev`
+   - open `/`
+   - fill in name, clean time, mood, and optional mind text
+   - click `Join Meeting`
+   - do not touch anything until the room asks you to
+   - complete one full meeting and one crisis interruption check
+
+If any required validation is blocked by missing credentials or environment, write the exact blocker into `Progress`, `Surprises & Discoveries`, and `Outcomes & Retrospective`. Do not overclaim.
+
+For the final manual acceptance, the expected observations are concrete:
+
+- within a few seconds of `Join Meeting`, Marcus has spoken and used the user's name
+- the user never sees a phase badge, meeting id, or operator toolbar
+- the room reaches the topic chooser without any extra click
+- each user prompt appears only after the room has spoken
+- `Keep coming back` appears before the page moves to reflection
+- in listening-only mode, the room never asks the user to share after topic selection
+- in crisis mode, no queued room beat fires after the crisis response begins
+
+## Artifacts And Notes
+
+Capture these artifacts as the work proceeds:
+
+- one short log or test assertion proving the route selected the crosstalk prompt
+- one short log or test assertion proving the route selected the hard-question prompt
+- one short log or test assertion proving the route selected the farewell prompt
+- one test or log proving the roster reload returns the same visitor ids and `seatOrder`
+- one screenshot or Playwright artifact of the restored room shell with no dashboard chrome
+- one transcript excerpt showing the final close sequence with `Keep coming back` and the private farewell
+
+Keep these artifacts concise. They are evidence for the next contributor, not a scrapbook.
+
+## Smell Test Inventory
+
+Before calling the plan done, verify all of these are false:
+
+- The user must click anything other than `Join`, `Introduce yourself`, `Share`, `Pass`, topic choice, or end-state buttons to move the meeting forward.
+- A phase label, meeting ID, status string, or debug number is visible during the meeting.
+- The loading state for a speaker is a spinner or skeleton instead of a room-native thinking indicator.
+- The empty chair can be bypassed.
+- Crisis appears as a modal or overlay while the feed continues underneath.
+- Topic, name, or mood remains editable once the meeting page is open.
+- The topic chooser is a text input.
+- Characters speak with no pause between turns.
+- The intro order is not `marcus -> heather -> meechie -> gemini -> gypsy -> chrystal -> visitor 1 -> visitor 2`.
+- The meeting ends without `Keep coming back`.
+- The last line after `Keep coming back` sounds like a generic support message instead of a direct goodbye from a person in the room.
+
+## Completion Litmus Test
+
+Do not mark this ExecPlan done until the executing agent can answer `yes` to every question below:
+
+1. If I join a meeting and put my hands in my lap, does the room start itself without any hidden fallback control?
+2. Does Marcus say the user's name early, and does the room pause on purpose rather than showing infrastructure?
+3. Do all eight participants introduce themselves before the user is asked to do anything except introduce themself?
+4. Does the user pick from the curated topic list instead of inventing the topic from scratch?
+5. Do three rounds happen, with the room carrying most of the talking?
+6. Does a hard question happen only after the user has really shown up?
+7. Does crisis stop the meeting cold instead of decorating it?
+8. Does the meeting close with `Keep coming back` and one private farewell?
+9. Could a tired, first-time user mistake this for a room instead of an interface?
+
+If any answer is `no`, the restore is not done.
+
+## Audit Revision History
+
+Round 1 self-audit changes made while authoring this plan:
+
+- Added the meeting-participant roster seam after discovering that the random visitors are impossible to persist with the current adapter.
+- Added the explicit "missing Appendix A body" rule so the executing agent does not invent traceability.
+- Added the conflict hierarchy and divergence budget so timing, UX, and phase order cannot be traded away casually.
+- Added the explicit permission to delete the admin UI by name so the executing agent does not preserve the dashboard out of caution.
+- Added the voice audit anchors so the executing agent can catch "therapist voice" even when tests pass.
+
+Round 2 self-audit changes made while authoring this plan:
+
+- Added explicit instructions that the share route must honor frontend-provided round speakers inside the persisted roster, while still enforcing ritual speakers for opening and closing beats.
+- Added the seeded speaking-order rule so refresh remains stable without inventing new schema.
+- Added explicit `DEFERRED.md` handling and anti-scope-creep language.
+- Added the smell test item for transcript debug metadata after noticing that `ShareMessage.svelte` currently exposes significance and sequence data.
+
+Round 3 self-audit changes made after a hostile plan review:
+
+- Embedded the experience target and explicit backend gaps directly into the plan so it no longer depends on external prompt context.
+- Added the missing named ExecPlan sections: `Plan Of Work`, `Interfaces And Dependencies`, `Concrete Steps`, `Validation And Acceptance`, and `Artifacts And Notes`.
+- Corrected the impossible visitor-id assumption by switching the roster plan to database-created visitor ids plus persisted `seat_order`.
+- Corrected the interaction-type model so `opening`, `reading`, and `intro` stay phase-driven instead of becoming illegal enum values.
+- Added the missing share-interaction persistence work in the database seam, fixture, adapter, and migration.
+- Added transcript bootstrap, deterministic randomness, explicit cancellation state, and listening-only handling as first-class plan requirements.
+
+Exit condition for the authoring audit:
+
+The third pass produced fewer than three material changes to the plan structure. The remaining edits were clarifications, not missing execution-critical work.
+
+## Revision Note
+
+2026-03-19: Initial authored version, then revised through three audit passes. The critical fixes were making the document self-contained, correcting the impossible visitor-id story, restoring truthful interaction-type persistence, and adding listening-only, transcript bootstrap, deterministic randomness, and cancellation as explicit requirements instead of implied behavior.


### PR DESCRIPTION
## Summary
- restore room-led meeting flow on top of a persisted roster and real interaction types
- make topic-selection ask/ack explicit without inventing a new route or schema
- stop crisis from letting queued room beats continue underneath it
- update plan/log/lesson docs to match the current state

## Verification
- `npm run test:unit -- --run src/lib/core/character-selector.spec.ts src/lib/seams/database/contract.test.ts src/lib/server/seams/database/adapter.spec.ts src/lib/server/routes/meeting-page-load.spec.ts src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-ritual-phase.integration.spec.ts`
- `npm run test:unit -- --run src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-ritual-phase.integration.spec.ts`
- `timeout 180s npm run check` (0 errors, 8 known Svelte rune warnings documented in `DEFERRED.md`)
- `timeout 180s npx eslint src/routes/meeting/[id]/+page.svelte src/routes/meeting/[id]/share/+server.ts src/lib/components/MeetingCircle.svelte src/lib/components/MeetingReflection.svelte src/lib/components/SystemMessage.svelte src/lib/components/UserInput.svelte src/lib/core/character-selector.ts src/lib/core/character-selector.spec.ts src/lib/server/routes/meeting-share.spec.ts src/lib/server/routes/meeting-ritual-phase.integration.spec.ts`

## Remaining gaps
- full replay-free mid-beat refresh recovery is still deferred
- newcomer-specific spoken welcome before topic selection is still partly local UI text
- `+page.svelte` still emits 8 `state_referenced_locally` Svelte warnings

See `DEFERRED.md` and `plans/restore-virtual-recovery-meeting-execplan.md` for the explicit carry-forward list.
